### PR TITLE
Generate launch.json and task.json configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "edge-vscode",
   "displayName": "Edge Engineer",
   "description": "Build and debug EdgeOS applications with Visual Studio Code",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "publisher": "edge-engineer",
   "repository": {
     "type": "git",

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -1,29 +1,104 @@
-// Portions of this code taken from the VS Code Swift open source project
-// (https://github.com/vscode‑swift), licensed under Apache 2.0.
+// Portions of this code taken from the VS Code Swift open source project
+// (https://github.com/vscode‑swift), licensed under Apache 2.0.
 
 import { EdgeFolderContext } from "../EdgeFolderContext";
 import * as vscode from "vscode";
 import { getFolderAndNameSuffix } from "./buildConfig";
 import { EDGE_LAUNCH_CONFIG_TYPE } from "./EdgeDebugConfigurationProvider";
+import { DeviceManager } from "../models/DeviceManager";
 
 export async function makeDebugConfigurations(
     context: EdgeFolderContext
 ): Promise<boolean> {
-    // TODO: Add `autoGenerateLaunchConfigurations` setting like the Swift extension.
+    console.log(`[Edge] Checking for debug configurations in folder: ${context.swift.folder.fsPath}`);
+    
+    // Get the launch configurations for this folder
     const wsLaunchSection = vscode.workspace.getConfiguration("launch", context.swift.folder);
+    const configurations = wsLaunchSection.get<any[]>("configurations") || [];
+    console.log(`[Edge] Found ${configurations.length} existing configurations`);
+    
+    // Check if there are already Edge configurations
+    const hasEdgeConfigurations = configurations.some(
+        config => config.type === EDGE_LAUNCH_CONFIG_TYPE
+    );
+    
+    // If there are already Edge configurations, don't add more
+    if (hasEdgeConfigurations) {
+        console.log(`[Edge] Edge configurations already exist, skipping`);
+        return false;
+    }
+    
+    // Create Edge debug configurations for each executable
+    const edgeConfigurations = await createExecutableConfigurations(context);
+    console.log(`[Edge] Generated ${edgeConfigurations.length} new Edge configurations`);
+    
+    if (edgeConfigurations.length === 0) {
+        console.log(`[Edge] No executable products found, skipping`);
+        return false;
+    }
+    
+    // Add the new configurations at the beginning of the array
+    const newConfigurations = [...edgeConfigurations, ...configurations];
+    
+    // Update the launch.json
+    console.log(`[Edge] Updating launch.json with ${edgeConfigurations.length} Edge configurations`);
+    await wsLaunchSection.update("configurations", newConfigurations, vscode.ConfigurationTarget.WorkspaceFolder);
+    console.log(`[Edge] Successfully updated launch.json`);
+    
     return true;
 }
 
 async function createExecutableConfigurations(context: EdgeFolderContext) {
+    console.log(`[Edge] Generating debug configurations for folder: ${context.swift.folder.fsPath}`);
+    
     const executableProducts = await context.swift.swiftPackage.executableProducts;
+    console.log(`[Edge] Found ${executableProducts.length} executable products`);
+    
+    if (executableProducts.length === 0) {
+        return [];
+    }
 
     // Windows understand the forward slashes, so make the configuration unified as posix path
     // to make it easier for users switching between platforms.
     const { folder, nameSuffix } = getFolderAndNameSuffix(context.swift, undefined, "posix");
+    console.log(`[Edge] Using folder path: ${folder}`);
 
-    return executableProducts.flatMap(product => {
-        const baseConfig = {
+    return executableProducts.map(product => {
+        console.log(`[Edge] Creating configuration for product: ${product.name}`);
+        return {
             type: EDGE_LAUNCH_CONFIG_TYPE,
+            name: `Debug ${product.name} on EdgeOS`,
+            request: "attach",
+            target: product.name,
+            cwd: folder,
+            preLaunchTask: `edge: Run ${product.name}`
         };
     });
+}
+
+/**
+ * Checks if any folder in the workspace has an Edge debug configuration
+ * @returns true if at least one folder has an Edge configuration
+ */
+export async function hasAnyEdgeDebugConfiguration(): Promise<boolean> {
+    console.log(`[Edge] Checking if any folder has Edge debug configurations`);
+    
+    if (!vscode.workspace.workspaceFolders) {
+        console.log(`[Edge] No workspace folders found`);
+        return false;
+    }
+    
+    for (const folder of vscode.workspace.workspaceFolders) {
+        console.log(`[Edge] Checking folder: ${folder.name}`);
+        const wsLaunchSection = vscode.workspace.getConfiguration("launch", folder.uri);
+        const configurations = wsLaunchSection.get<any[]>("configurations") || [];
+        
+        if (configurations.some(config => config.type === EDGE_LAUNCH_CONFIG_TYPE)) {
+            console.log(`[Edge] Found Edge configuration in folder: ${folder.name}`);
+            return true;
+        }
+    }
+    
+    console.log(`[Edge] No Edge configurations found in any folder`);
+    return false;
 }

--- a/src/utilities/EdgeProjectDetector.ts
+++ b/src/utilities/EdgeProjectDetector.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as util from 'util';
+import { exec } from 'child_process';
+
+/**
+ * A utility for detecting if a workspace folder is an Edge project.
+ * This could check various signals:
+ * 1. Package.swift dependencies that include Edge libraries
+ * 2. Presence of .edge directory or configuration
+ * 3. Output from running `edge info` in the directory
+ */
+export class EdgeProjectDetector {
+  // Edge-specific dependency URLs that indicate an Edge project
+  private static readonly EDGE_DEPENDENCY_PATTERNS = [
+    'edge-runtime',
+    'edge-agent',
+    'edge-proxy',
+    'apache-edge',
+    'apache/edge'
+  ];
+
+  /**
+   * Checks if the given folder is an Edge project
+   * @param folderPath Path to the folder to check
+   * @returns Promise that resolves to true if it's an Edge project, false otherwise
+   */
+  public static async isEdgeProject(folderPath: string): Promise<boolean> {
+    // Method 1: Check Package.swift for Edge dependencies
+    const packageSwiftPath = path.join(folderPath, 'Package.swift');
+    try {
+      const packageSwiftExists = fs.existsSync(packageSwiftPath);
+      if (packageSwiftExists) {
+        const packageContent = await fs.promises.readFile(packageSwiftPath, 'utf8');
+        
+        // Check for Edge-specific dependencies in the Package.swift
+        for (const pattern of this.EDGE_DEPENDENCY_PATTERNS) {
+          if (packageContent.includes(pattern)) {
+            return true;
+          }
+        }
+      }
+    } catch (error) {
+      // If there's an error reading the file, continue to the next method
+      console.error(`Error checking Package.swift: ${error}`);
+    }
+
+    // Method 2: Check for .edge directory or configuration
+    const edgeDirPath = path.join(folderPath, '.edge');
+    const edgeConfigPath = path.join(folderPath, 'edge.json');
+    try {
+      if (fs.existsSync(edgeDirPath) || fs.existsSync(edgeConfigPath)) {
+        return true;
+      }
+    } catch (error) {
+      console.error(`Error checking for .edge directory or config: ${error}`);
+    }
+
+    // Method 3: Run edge info command in the directory
+    // This method is more expensive, so we only run it if the previous methods failed
+    try {
+      const execPromise = util.promisify(exec);
+      const { stdout } = await execPromise('edge info', { cwd: folderPath });
+      
+      // If the command returns successfully and doesn't contain error messages,
+      // it's likely an Edge project
+      if (stdout && !stdout.toLowerCase().includes('error')) {
+        return true;
+      }
+    } catch (error) {
+      // Command failed, which is expected for non-Edge projects
+      // No need to log this error
+    }
+
+    // If we've made it this far, it's not an Edge project
+    return false;
+  }
+} 


### PR DESCRIPTION
- waiting until the swift extension loads the folder context before triggering config generation
- generating launch.json config
- to generate the edgeOS config we have a project detector that tries several options, including looking for `.edge/` in the project directory.

This works best with https://github.com/edgeengineer/edge-agent/pull/38 - so an update cli