### PR TITLE
Fix CLI auto-detection on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendy-vscode",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendy-vscode",
-      "version": "0.0.13",
+      "version": "0.1.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
@@ -1805,7 +1805,6 @@
       "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.30.1",
         "@typescript-eslint/types": "8.30.1",
@@ -2360,7 +2359,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3826,7 +3824,6 @@
       "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8727,7 +8724,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/models/DeviceManager.ts
+++ b/src/models/DeviceManager.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { Device } from "./Device";
 import { v7 as uuidv7 } from "uuid";
-import { exec, execFile } from "child_process";
+import { execFile } from "child_process";
 import { WendyCLI } from "../wendy-cli/wendy-cli";
 
 export interface EthernetDevice {
@@ -154,7 +154,7 @@ export class DeviceManager implements vscode.Disposable {
       return;
     }
 
-    exec(`${cli.path} discover --json`, (error, stdout, stderr) => {
+    execFile(cli.path, ['discover', '--json'], (error, stdout, stderr) => {
       if (stderr) {
         console.error('Device discovery stderr:', stderr);
       }
@@ -283,7 +283,7 @@ export class DeviceManager implements vscode.Disposable {
     }
 
     const output = await new Promise<string>((resolve, reject) => {
-      exec(`${cli.path} device version --device ${device.address} --json --check-updates --prerelease`, (error, stdout) => {
+      execFile(cli.path, ['device', 'version', '--device', device.address, '--json', '--check-updates', '--prerelease'], (error, stdout) => {
         if (error) {
           reject(error);
         }
@@ -385,7 +385,7 @@ export class DeviceManager implements vscode.Disposable {
     }, async () => {
       try {
         await new Promise<string>((resolve, reject) => {
-          exec(`${cli.path} device update --device ${device.address}`, (error, stdout) => {
+          execFile(cli.path, ['device', 'update', '--device', device.address], (error, stdout) => {
             if (error) {
               reject(error);
             }
@@ -423,7 +423,7 @@ export class DeviceManager implements vscode.Disposable {
     }
 
     let output = await new Promise<string>((resolve, reject) => {
-      exec(`${cli.path} wifi list --device ${device.address} --json`, (error, stdout) => {
+      execFile(cli.path, ['wifi', 'list', '--device', device.address, '--json'], (error, stdout) => {
         if (error) {
           reject(error);
         }
@@ -454,7 +454,7 @@ export class DeviceManager implements vscode.Disposable {
     }
 
     output = await new Promise<string>((resolve, reject) => {
-      exec(`${cli.path} wifi connect \"${network.label}\" --device ${device.address} --password \"${password}\" --json`, (error, stdout, stderr) => {
+      execFile(cli.path, ['wifi', 'connect', network.label, '--device', device.address, '--password', password, '--json'], (error, stdout, stderr) => {
         if (error) {
           reject(error);
         }
@@ -518,7 +518,7 @@ export class DeviceManager implements vscode.Disposable {
     }
 
     const output = await new Promise<string>((resolve, reject) => {
-      exec(`${cli.path} --json device apps list --device ${deviceAddress}`, (error, stdout, stderr) => {
+      execFile(cli.path, ['--json', 'device', 'apps', 'list', '--device', deviceAddress], (error, stdout, stderr) => {
         if (error) {
           reject(new Error(stderr || error.message));
           return;
@@ -551,7 +551,7 @@ export class DeviceManager implements vscode.Disposable {
     }
 
     await new Promise<void>((resolve, reject) => {
-      exec(`${cli.path} device apps start "${appName}" --device ${deviceAddress}`, (error, stdout, stderr) => {
+      execFile(cli.path, ['device', 'apps', 'start', appName, '--device', deviceAddress], (error, stdout, stderr) => {
         if (error) {
           reject(new Error(stderr || error.message));
           return;
@@ -573,7 +573,7 @@ export class DeviceManager implements vscode.Disposable {
     }
 
     await new Promise<void>((resolve, reject) => {
-      exec(`${cli.path} device apps stop "${appName}" --device ${deviceAddress}`, (error, stdout, stderr) => {
+      execFile(cli.path, ['device', 'apps', 'stop', appName, '--device', deviceAddress], (error, stdout, stderr) => {
         if (error) {
           reject(new Error(stderr || error.message));
           return;
@@ -594,13 +594,13 @@ export class DeviceManager implements vscode.Disposable {
       throw new Error("Failed to create Wendy CLI");
     }
 
-    let args = `device apps remove "${appName}" --device ${deviceAddress}`;
+    const args = ['device', 'apps', 'remove', appName, '--device', deviceAddress];
     if (purgeImage) {
-      args += ' --purge-image';
+      args.push('--purge-image');
     }
 
     await new Promise<void>((resolve, reject) => {
-      exec(`${cli.path} ${args}`, (error, stdout, stderr) => {
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
           reject(new Error(stderr || error.message));
           return;
@@ -622,7 +622,7 @@ export class DeviceManager implements vscode.Disposable {
     }
 
     const output = await new Promise<string>((resolve, reject) => {
-      exec(`${cli.path} --json device wifi status --device ${deviceAddress}`, (error, stdout, stderr) => {
+      execFile(cli.path, ['--json', 'device', 'wifi', 'status', '--device', deviceAddress], (error, stdout, stderr) => {
         if (error) {
           reject(new Error(stderr || error.message));
           return;
@@ -658,7 +658,7 @@ export class DeviceManager implements vscode.Disposable {
     }
 
     await new Promise<void>((resolve, reject) => {
-      exec(`${cli.path} device wifi disconnect --device ${deviceAddress}`, (error, stdout, stderr) => {
+      execFile(cli.path, ['device', 'wifi', 'disconnect', '--device', deviceAddress], (error, stdout, stderr) => {
         if (error) {
           reject(new Error(stderr || error.message));
           return;

--- a/src/models/DiskManager.ts
+++ b/src/models/DiskManager.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { Disk } from "./Disk";
 import { WendyCLI } from "../wendy-cli/wendy-cli";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 
 export class DiskManager {
   private outputChannel: vscode.OutputChannel;
@@ -18,7 +18,7 @@ export class DiskManager {
 
     // Execute the wendy os list-drives command
     const output = await new Promise<string>((resolve, reject) => {
-      exec(`${cli.path} os list-drives --json --all`, (error, stdout) => {
+      execFile(cli.path, ['os', 'list-drives', '--json', '--all'], (error, stdout) => {
         if (error) {
           reject(error);
         }

--- a/src/models/ProjectManager.ts
+++ b/src/models/ProjectManager.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { WendyCLI } from "../wendy-cli/wendy-cli";
 
 export type EntitlementType = 'network' | 'video' | 'audio' | 'bluetooth' | 'gpu' | 'persist';
@@ -34,10 +34,10 @@ export class ProjectManager {
     }
 
     return new Promise((resolve, reject) => {
-      const command = `${cli.path} init --path "${projectPath}" --language ${language}`;
-      this.outputChannel.appendLine(`Executing: ${command}`);
+      const args = ['init', '--path', projectPath, '--language', language];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(' ')}`);
 
-      exec(command, (error, stdout, stderr) => {
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
           this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
@@ -67,10 +67,9 @@ export class ProjectManager {
     }
 
     return new Promise((resolve, reject) => {
-      const command = `${cli.path} ${args.join(' ')}`;
-      this.outputChannel.appendLine(`Executing: ${command}`);
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(' ')}`);
 
-      exec(command, { cwd: projectPath }, (error, stdout, stderr) => {
+      execFile(cli.path, args, { cwd: projectPath }, (error, stdout, stderr) => {
         if (error) {
           this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
@@ -98,10 +97,9 @@ export class ProjectManager {
       }
       args.push('--project', projectPath);
 
-      const command = `${cli.path} ${args.join(' ')}`;
-      this.outputChannel.appendLine(`Executing: ${command}`);
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(' ')}`);
 
-      exec(command, (error, stdout, stderr) => {
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
           this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
@@ -145,10 +143,9 @@ export class ProjectManager {
     args.push('--project', projectPath);
 
     return new Promise((resolve, reject) => {
-      const command = `${cli.path} ${args.join(' ')}`;
-      this.outputChannel.appendLine(`Executing: ${command}`);
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(' ')}`);
 
-      exec(command, (error, stdout, stderr) => {
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
           this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
@@ -172,10 +169,9 @@ export class ProjectManager {
     const args = ['project', 'entitlements', 'remove', '--entitlement-type', type, '--project', projectPath];
 
     return new Promise((resolve, reject) => {
-      const command = `${cli.path} ${args.join(' ')}`;
-      this.outputChannel.appendLine(`Executing: ${command}`);
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(' ')}`);
 
-      exec(command, (error, stdout, stderr) => {
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
           this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));

--- a/src/utilities/Imager.ts
+++ b/src/utilities/Imager.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { WendyCLI } from "../wendy-cli/wendy-cli";
 
 export class WendyImager {
@@ -9,7 +9,7 @@ export class WendyImager {
     }
 
     const output = await new Promise<string>((resolve, reject) => {
-      exec(`${cli.path} os supported-devices --json`, (error, stdout) => {
+      execFile(cli.path, ['os', 'supported-devices', '--json'], (error, stdout) => {
         if (error) {
           reject(error);
         }

--- a/src/wendy-cli/wendy-cli.ts
+++ b/src/wendy-cli/wendy-cli.ts
@@ -48,6 +48,12 @@ export class WendyCLI {
       let wendyCli: string;
       // TODO: Allow overriding the path via a setting.
       switch (process.platform) {
+        case "win32": {
+          const { stdout } = await execFile("where", ["wendy"]);
+          // `where` may return multiple lines; take the first match
+          wendyCli = stdout.trimEnd().split(/\r?\n/)[0];
+          break;
+        }
         case "darwin": {
           const { stdout } = await execFile("which", ["wendy"]);
           wendyCli = stdout.trimEnd();


### PR DESCRIPTION
This PR addresses the current issues from [WDY-851](https://linear.app/wendylabsinc/issue/WDY-851/wendy-vscode-extension-needs-to-be-tested-on-windows#comment-20cc1822) by fixing auto CLI discovery and command execution on Windows. When installing the Wendy CLI via `winget`, the executable is placed in `C:\Program Files\Wendy`. Since this directory has a space, many extension interactions would fail.

1. Changed `exec` to `execFile` for most extension interactions. This method respects spaces in filepaths and is slightly more secure than `exec` as it does not spawn a shell while still allowing stdout/stderr to be parsed.
2. Added a case for `win32` in the CLI auto detection which uses the Windows `where` command to locate the Wendy CLI. Previously, Windows was missing a case which fell back to using `/bin/sh` which does not exist on Windows.