### PR TITLE
feat(vscode): proposal for WendyOS#738

### DIFF
--- a/src/models/DeviceManager.ts
+++ b/src/models/DeviceManager.ts
@@ -27,6 +27,12 @@ export interface LANDevice {
   deviceType?: string;
   interfaceType?: string;
   isWendyDevice?: boolean;
+  /**
+   * Non-empty when the device is reachable over a USB/Ethernet-gadget interface.
+   * Mirrors the `usb` field added to LAN device entries in `wendy discover --json`.
+   * Example value: "enp0s20f0u9 480 Mbps"
+   */
+  usb?: string;
   apps?: LANDeviceApp[];
 }
 


### PR DESCRIPTION
The CLI's `wendy discover --json` output now includes a `usb` field on LAN device entries (e.g. `"usb": "enp0s20f0u9 480 Mbps"`) when a device is connected over USB/Ethernet gadget mode. The extension's `LANDevice` interface in `DeviceManager.ts` needs a `usb?: string` field added so the extension correctly models what the CLI returns. No other extension behaviour needs to change: the provider key strings ("docker", "local") are unchanged, the `Device.connectionType` values remain valid, and the display-name rename ("Local (This Device)" → "This Device") is a CLI TUI concern only.
