### PR TITLE
feat(vscode): proposal for WendyOS#859

### DIFF
--- a/docs/superpowers/plans/2026-05-21-camera-watch-button.md
+++ b/docs/superpowers/plans/2026-05-21-camera-watch-button.md
@@ -1,0 +1,219 @@
+# Camera Watch Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an inline eye icon button to each camera device in the Hardware tree view that opens a terminal running `wendy device camera view`.
+
+**Architecture:** `HardwareDeviceTreeItem` gains a `deviceAddress` field and a camera-specific `contextValue`. The package.json menu contribution wires the eye button to a new `wendyHardware.watchCamera` command, which is registered in `extension.ts` and opens a VS Code terminal.
+
+**Tech Stack:** TypeScript, VS Code Extension API, wendy CLI
+
+---
+
+### Task 1: Update `HardwareDeviceTreeItem` to carry device address and camera contextValue
+
+**Files:**
+- Modify: `src/sidebar/HardwareProvider.ts`
+
+- [ ] **Step 1: Open `src/sidebar/HardwareProvider.ts` and update the `HardwareDeviceTreeItem` constructor**
+
+  Change the constructor from:
+  ```typescript
+  export class HardwareDeviceTreeItem extends vscode.TreeItem {
+    constructor(
+      public readonly hardware: HardwareDevice
+    ) {
+      super(hardware.description || hardware.devicePath || '', vscode.TreeItemCollapsibleState.None);
+      this.contextValue = "hardwareDevice";
+      this.description = hardware.devicePath;
+      this.tooltip = this.formatTooltip();
+    }
+  ```
+  To:
+  ```typescript
+  export class HardwareDeviceTreeItem extends vscode.TreeItem {
+    constructor(
+      public readonly hardware: HardwareDevice,
+      public readonly deviceAddress: string
+    ) {
+      super(hardware.description || hardware.devicePath || '', vscode.TreeItemCollapsibleState.None);
+      this.contextValue = hardware.category === 'camera' ? 'hardwareDevice-camera' : 'hardwareDevice';
+      this.description = hardware.devicePath;
+      this.tooltip = this.formatTooltip();
+    }
+  ```
+
+- [ ] **Step 2: Update `getChildren` in `HardwareProvider` to pass `currentDevice.address`**
+
+  Change the category children branch from:
+  ```typescript
+  if (element instanceof HardwareCategoryTreeItem) {
+    return element.devices.map(hw => new HardwareDeviceTreeItem(hw));
+  }
+  ```
+  To:
+  ```typescript
+  if (element instanceof HardwareCategoryTreeItem) {
+    return element.devices.map(hw => new HardwareDeviceTreeItem(hw, currentDevice.address));
+  }
+  ```
+
+- [ ] **Step 3: Verify TypeScript compiles with no errors**
+
+  ```bash
+  cd /Users/joannisorlandos/git/wendy/wendy-vscode && npm run compile 2>&1
+  ```
+  Expected: no errors (exit 0).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add src/sidebar/HardwareProvider.ts
+  git commit -m "feat: add deviceAddress and camera contextValue to HardwareDeviceTreeItem"
+  ```
+
+---
+
+### Task 2: Add `wendyHardware.watchCamera` command and inline menu entry to `package.json`
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the command entry to the `contributes.commands` array in `package.json`**
+
+  Find the existing `wendyHardware.refresh` command entry:
+  ```json
+  {
+    "command": "wendyHardware.refresh",
+    "title": "Refresh",
+    "icon": "$(refresh)"
+  }
+  ```
+  Add a new entry immediately after it:
+  ```json
+  {
+    "command": "wendyHardware.watchCamera",
+    "title": "Watch Camera",
+    "icon": "$(eye)"
+  }
+  ```
+
+- [ ] **Step 2: Add the inline menu entry to `contributes.menus.view/item/context`**
+
+  Find the last entry in the `view/item/context` array (currently the `wendyDisks.flashDisk` entry or similar), and append:
+  ```json
+  {
+    "command": "wendyHardware.watchCamera",
+    "when": "view == wendyHardware && viewItem == hardwareDevice-camera",
+    "group": "inline"
+  }
+  ```
+
+- [ ] **Step 3: Verify the extension compiles and the JSON is valid**
+
+  ```bash
+  cd /Users/joannisorlandos/git/wendy/wendy-vscode && npm run compile 2>&1
+  ```
+  Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add package.json
+  git commit -m "feat: register wendyHardware.watchCamera command and inline menu entry"
+  ```
+
+---
+
+### Task 3: Register the `wendyHardware.watchCamera` command handler in `extension.ts`
+
+**Files:**
+- Modify: `src/extension.ts`
+
+- [ ] **Step 1: Add the import for `HardwareDeviceTreeItem` at the top of `extension.ts`**
+
+  Find the existing import:
+  ```typescript
+  import { HardwareProvider } from "./sidebar/HardwareProvider";
+  ```
+  Change it to:
+  ```typescript
+  import { HardwareProvider, HardwareDeviceTreeItem } from "./sidebar/HardwareProvider";
+  ```
+
+- [ ] **Step 2: Register the command handler inside the `context.subscriptions.push(...)` block in `extension.ts`**
+
+  Find the existing hardware refresh command registration:
+  ```typescript
+  // Hardware refresh command
+  vscode.commands.registerCommand("wendyHardware.refresh", () => {
+    hardwareProvider.refresh();
+  }),
+  ```
+  Add this new command immediately after it (inside the same `context.subscriptions.push(...)` call, separated by a comma):
+  ```typescript
+  // Watch camera command
+  vscode.commands.registerCommand("wendyHardware.watchCamera", async (item: HardwareDeviceTreeItem) => {
+    if (!item) {
+      return;
+    }
+
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      vscode.window.showErrorMessage("Wendy CLI not found");
+      return;
+    }
+
+    const args = ['device', 'camera', 'view', '--device', item.deviceAddress];
+    const match = item.hardware.devicePath?.match(/(\d+)$/);
+    if (match) {
+      args.push('--id', match[1]);
+    }
+
+    const label = item.hardware.description || item.hardware.devicePath || 'Camera';
+    const terminal = vscode.window.createTerminal({
+      name: `Camera: ${label}`,
+      shellPath: cli.path,
+      shellArgs: args
+    });
+    terminal.show();
+  }),
+  ```
+
+- [ ] **Step 3: Compile to confirm no TypeScript errors**
+
+  ```bash
+  cd /Users/joannisorlandos/git/wendy/wendy-vscode && npm run compile 2>&1
+  ```
+  Expected: no errors (exit 0).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add src/extension.ts
+  git commit -m "feat: implement watchCamera command handler to open camera terminal"
+  ```
+
+---
+
+### Task 4: Manual smoke test
+
+- [ ] **Step 1: Launch the extension in debug mode**
+
+  Press `F5` in VS Code with the `wendy-vscode` workspace open, or run the "Run Extension" launch configuration. A new Extension Development Host window opens.
+
+- [ ] **Step 2: Select a connected Wendy device in the Devices panel**
+
+  In the Extension Development Host, open the WendyOS sidebar, select a device that has cameras.
+
+- [ ] **Step 3: Open the Hardware tab and expand "Camera"**
+
+  Confirm that each camera item now shows an eye icon button inline on the right side of the row.
+
+- [ ] **Step 4: Click the eye button on a camera item**
+
+  A new terminal named `Camera: <description>` should open and immediately run `wendy device camera view --device <addr> --id <n>`. A native video window should appear.
+
+- [ ] **Step 5: Verify devices without cameras show no eye button**
+
+  Expand another category (e.g., "Audio" or "Usb") and confirm those items have no eye button.

--- a/docs/superpowers/specs/2026-05-21-camera-watch-button-design.md
+++ b/docs/superpowers/specs/2026-05-21-camera-watch-button-design.md
@@ -1,0 +1,31 @@
+# Camera Watch Button
+
+## Summary
+
+Add an inline eye icon button to each camera device in the Hardware tab. Clicking it opens a VS Code terminal running `wendy device camera view`, which opens a native video window.
+
+## Architecture
+
+Four files change:
+
+- **`src/sidebar/HardwareProvider.ts`** — `HardwareDeviceTreeItem` gets a `deviceAddress` constructor param and sets `contextValue` to `hardwareDevice-camera` when `hardware.category === 'camera'`, otherwise `hardwareDevice`. `getChildren` passes `currentDevice.address` when building device items.
+- **`src/extension.ts`** — Register `wendyHardware.watchCamera` command. Extract the camera ID from `devicePath` (e.g. `/dev/video0` → `0`), build args `['device', 'camera', 'view', '--device', address, '--id', id]`, open a terminal.
+- **`package.json` commands** — Add `wendyHardware.watchCamera` with title "Watch Camera" and icon `$(eye)`.
+- **`package.json` menus** — Add inline `view/item/context` entry: `when: view == wendyHardware && viewItem == hardwareDevice-camera`.
+
+## Data Flow
+
+1. User expands Camera category → `getChildren` maps each `HardwareDevice` to a `HardwareDeviceTreeItem(hw, currentDevice.address)` with `contextValue = "hardwareDevice-camera"`.
+2. VS Code renders the `$(eye)` inline button via the menu contribution.
+3. User clicks → `wendyHardware.watchCamera` fires with the tree item.
+4. Handler parses ID from `devicePath`, creates terminal, runs `wendy device camera view`.
+
+## Error Handling
+
+- If no device address: error message (shouldn't happen since items only render when a device is selected).
+- If Wendy CLI not found: show error message.
+- If `devicePath` has no trailing number: omit `--id` flag (CLI uses device default).
+
+## Testing
+
+Manual: select a device, open Hardware tab, expand Camera category, click the eye button — a terminal opens and a video window appears.

--- a/src/sidebar/OperatingSystemCacheProvider.ts
+++ b/src/sidebar/OperatingSystemCacheProvider.ts
@@ -1,238 +1,81 @@
 import * as vscode from "vscode";
-import * as path from "path";
-import * as fs from "fs/promises";
-import * as os from "os";
+import { WendyCLI } from "../wendy-cli/wendy-cli";
+import { execFile } from "../utilities/utilities";
 
-export class CacheTreeItem extends vscode.TreeItem {
-  constructor(
-    public readonly fullPath: string,
-    public readonly isDirectory: boolean
-  ) {
-    super(
-      path.basename(fullPath) || fullPath,
-      isDirectory
-        ? vscode.TreeItemCollapsibleState.Collapsed
-        : vscode.TreeItemCollapsibleState.None
-    );
-
-    this.resourceUri = vscode.Uri.file(fullPath);
-    this.contextValue = isDirectory
-      ? "operatingSystemCacheDirectory"
-      : "operatingSystemCacheFile";
-    this.iconPath = new vscode.ThemeIcon(isDirectory ? "folder" : "file");
-
-    if (!isDirectory) {
-      this.command = {
-        command: "vscode.open",
-        title: "Open File",
-        arguments: [this.resourceUri],
-      };
-    }
-  }
+export interface OsCacheEntry {
+  name: string;
+  sizeBytes: number;
+  size: string;
 }
 
 export class OperatingSystemCacheProvider
-  implements vscode.TreeDataProvider<CacheTreeItem>, vscode.Disposable
+  implements vscode.TreeDataProvider<OsCacheItem>
 {
-  private readonly _onDidChangeTreeData =
-    new vscode.EventEmitter<CacheTreeItem | undefined | null | void>();
+  private _onDidChangeTreeData = new vscode.EventEmitter<
+    OsCacheItem | undefined | void
+  >();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-  private readonly disposables: vscode.Disposable[] = [];
-  private watcher?: vscode.FileSystemWatcher;
-  private watcherDisposables: vscode.Disposable[] = [];
-  private refreshTimeout?: NodeJS.Timeout;
-  private currentRoot: string | undefined;
-
-  constructor() {
-    this.disposables.push(
-      vscode.workspace.onDidChangeConfiguration((event) => {
-        if (event.affectsConfiguration("wendy.cache.root")) {
-          this.ensureWatcher(true);
-        }
-      })
-    );
-
-    this.ensureWatcher(false);
-  }
+  constructor(private readonly outputChannel: vscode.OutputChannel) {}
 
   refresh(): void {
     this._onDidChangeTreeData.fire();
   }
 
-  getTreeItem(element: CacheTreeItem): vscode.TreeItem {
+  getTreeItem(element: OsCacheItem): vscode.TreeItem {
     return element;
   }
 
-  async getChildren(element?: CacheTreeItem): Promise<CacheTreeItem[]> {
-    this.ensureWatcher(false);
-
-    const targetPath = element?.fullPath ?? this.getCacheRoot();
-
-    if (!(await this.pathExists(targetPath))) {
+  async getChildren(element?: OsCacheItem): Promise<OsCacheItem[]> {
+    if (element) {
       return [];
     }
 
-    return this.getDirectoryEntries(targetPath);
+    const entries = await this.listOsCacheEntries();
+    if (entries.length === 0) {
+      return [new OsCacheEmptyItem()];
+    }
+    return entries.map((e) => new OsCacheItem(e));
   }
 
-  getRootPath(): string {
-    return this.getCacheRoot();
-  }
+  private async listOsCacheEntries(): Promise<OsCacheEntry[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      return [];
+    }
 
-  private async getDirectoryEntries(
-    directory: string
-  ): Promise<CacheTreeItem[]> {
     try {
-      const dirents = await fs.readdir(directory, { withFileTypes: true });
-
-      const entries = dirents
-        .map((entry) => {
-          const entryPath = path.join(directory, entry.name);
-          return {
-            entryPath,
-            isDirectory: entry.isDirectory(),
-            name: entry.name,
-          };
-        })
-        .sort((a, b) => {
-          if (a.isDirectory !== b.isDirectory) {
-            return a.isDirectory ? -1 : 1;
-          }
-
-          return a.name.localeCompare(b.name);
-        });
-
-      return entries.map(
-        (entry) => new CacheTreeItem(entry.entryPath, entry.isDirectory)
-      );
+      const { stdout } = await execFile(cli.path, [
+        "--json",
+        "os",
+        "cache",
+        "list",
+      ]);
+      const parsed: OsCacheEntry[] = JSON.parse(stdout.trim());
+      return Array.isArray(parsed) ? parsed : [];
     } catch (error) {
-      const err = error as NodeJS.ErrnoException;
-      if (err?.code === "ENOENT" || err?.code === "EACCES") {
-        return [];
-      }
-
-      void vscode.window.showErrorMessage(
-        `Failed to read Wendy cache directory: ${err?.message ?? error}`
+      this.outputChannel.appendLine(
+        `Failed to list OS cache: ${error instanceof Error ? error.message : String(error)}`
       );
       return [];
     }
   }
+}
 
-  private ensureWatcher(forceRefresh: boolean): void {
-    const rootPath = this.getCacheRoot();
-
-    if (!forceRefresh && this.currentRoot === rootPath && this.watcher) {
-      return;
-    }
-
-    this.currentRoot = rootPath;
-    this.resetWatcher(rootPath);
+export class OsCacheItem extends vscode.TreeItem {
+  constructor(public readonly entry: OsCacheEntry) {
+    super(entry.name, vscode.TreeItemCollapsibleState.None);
+    this.description = entry.size;
+    this.tooltip = `${entry.name}\n${entry.size} (${entry.sizeBytes.toLocaleString()} bytes)`;
+    this.contextValue = "osCacheEntry";
+    this.iconPath = new vscode.ThemeIcon("archive");
   }
+}
 
-  private resetWatcher(rootPath: string): void {
-    this.disposeWatcher();
-
-    try {
-      const pattern = new vscode.RelativePattern(rootPath, "**/*");
-      const watcher = vscode.workspace.createFileSystemWatcher(pattern);
-      this.watcher = watcher;
-
-      const onFsEvent = (): void => {
-        this.scheduleRefresh();
-      };
-
-      this.watcherDisposables = [
-        watcher.onDidCreate(onFsEvent),
-        watcher.onDidChange(onFsEvent),
-        watcher.onDidDelete(onFsEvent),
-      ];
-    } catch (error) {
-      const err = error as Error;
-      void vscode.window.showErrorMessage(
-        `Failed to watch Wendy cache directory: ${err.message}`
-      );
-      this.watcher = undefined;
-      this.watcherDisposables = [];
-    }
-
-    this.scheduleRefresh();
-  }
-
-  private scheduleRefresh(): void {
-    if (this.refreshTimeout) {
-      clearTimeout(this.refreshTimeout);
-    }
-
-    this.refreshTimeout = setTimeout(() => {
-      this.refresh();
-      this.refreshTimeout = undefined;
-    }, 200);
-  }
-
-  private getCacheRoot(): string {
-    const configuredRoot = vscode.workspace
-      .getConfiguration("wendy")
-      .get<string>("cache.root");
-    const trimmed = configuredRoot?.trim();
-
-    if (trimmed) {
-      return path.resolve(this.expandHome(trimmed));
-    }
-
-    if (process.platform === "win32") {
-      const localAppData =
-        process.env.LOCALAPPDATA ||
-        path.join(os.homedir(), "AppData", "Local");
-      return path.join(localAppData, ".wendy", "images");
-    }
-
-    if (process.platform === "darwin") {
-      return path.join(os.homedir(), "Library", "Caches", ".wendy", "images");
-    }
-
-    // Linux: use XDG_CACHE_HOME or fallback to ~/.cache
-    const xdgCache = process.env.XDG_CACHE_HOME || path.join(os.homedir(), ".cache");
-    return path.join(xdgCache, ".wendy", "images");
-  }
-
-  private expandHome(targetPath: string): string {
-    if (targetPath === "~") {
-      return os.homedir();
-    }
-
-    if (targetPath.startsWith("~/") || targetPath.startsWith("~\\")) {
-      return path.join(os.homedir(), targetPath.slice(2));
-    }
-    return targetPath;
-  }
-
-  private async pathExists(targetPath: string): Promise<boolean> {
-    try {
-      await fs.access(targetPath);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private disposeWatcher(): void {
-    this.watcher?.dispose();
-    this.watcher = undefined;
-
-    this.watcherDisposables.forEach((disposable) => disposable.dispose());
-    this.watcherDisposables = [];
-  }
-
-  dispose(): void {
-    this.disposeWatcher();
-
-    if (this.refreshTimeout) {
-      clearTimeout(this.refreshTimeout);
-      this.refreshTimeout = undefined;
-    }
-
-    this.disposables.forEach((disposable) => disposable.dispose());
-    this._onDidChangeTreeData.dispose();
+class OsCacheEmptyItem extends vscode.TreeItem {
+  constructor() {
+    super("No cached OS images", vscode.TreeItemCollapsibleState.None);
+    this.contextValue = "osCacheEmpty";
+    this.iconPath = new vscode.ThemeIcon("info");
   }
 }

--- a/src/sidebar/OperatingSystemCacheProvider.ts
+++ b/src/sidebar/OperatingSystemCacheProvider.ts
@@ -8,11 +8,13 @@ export interface OsCacheEntry {
   size: string;
 }
 
+type OsCacheTreeItem = OsCacheItem | OsCacheEmptyItem;
+
 export class OperatingSystemCacheProvider
-  implements vscode.TreeDataProvider<OsCacheItem>
+  implements vscode.TreeDataProvider<OsCacheTreeItem>
 {
   private _onDidChangeTreeData = new vscode.EventEmitter<
-    OsCacheItem | undefined | void
+    OsCacheTreeItem | undefined | void
   >();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
@@ -22,11 +24,11 @@ export class OperatingSystemCacheProvider
     this._onDidChangeTreeData.fire();
   }
 
-  getTreeItem(element: OsCacheItem): vscode.TreeItem {
+  getTreeItem(element: OsCacheTreeItem): vscode.TreeItem {
     return element;
   }
 
-  async getChildren(element?: OsCacheItem): Promise<OsCacheItem[]> {
+  async getChildren(element?: OsCacheTreeItem): Promise<OsCacheTreeItem[]> {
     if (element) {
       return [];
     }


### PR DESCRIPTION
The CLI PR adds proper `--json` output to `wendy cache list` and `wendy os cache list`. Previously the docs noted `--json` was broken; now both commands return well-defined JSON arrays when `--json` is passed explicitly.

For `wendy os cache list --json`, each element has:
- `name` (string): filename of the cached OS image
- `sizeBytes` (integer): size in bytes
- `size` (string): human-readable size

The extension's `OperatingSystemCacheProvider` should be updated to invoke `wendy os cache list --json` and parse the structured response instead of parsing human-readable text output, using the now-stable JSON contract.
