### PR TITLE
feat(vscode): proposal for WendyOS#895

### DIFF
--- a/schemas/wendy-schema.json
+++ b/schemas/wendy-schema.json
@@ -34,11 +34,27 @@
       "default": false,
       "description": "Enable debug mode."
     },
+    "isolation": {
+      "type": "string",
+      "description": "Isolation mode applied to every service in a compose group (e.g. \"shared-ipc\"). Has no effect for single-service apps.",
+      "examples": ["shared-ipc"]
+    },
+    "runtimes": {
+      "$ref": "#/$defs/runtimesConfig",
+      "description": "Default runtime configuration applied to every service in a compose group. Per-service entries in \"services\" can override this."
+    },
     "entitlements": {
       "type": "array",
-      "description": "Capabilities the app requires (GPU, network, Bluetooth, etc.).",
+      "description": "Capabilities the app requires (GPU, network, Bluetooth, etc.). For compose apps, declare per-service entitlements under \"services\" instead.",
       "items": {
         "$ref": "#/$defs/entitlement"
+      }
+    },
+    "services": {
+      "type": "object",
+      "description": "Compose-companion service overrides. Keys must match Docker Compose service names. Use this to add Wendy-specific entitlements or runtime config to individual services without modifying docker-compose.yml.",
+      "additionalProperties": {
+        "$ref": "#/$defs/serviceConfig"
       }
     },
     "readiness": {
@@ -62,6 +78,52 @@
     }
   },
   "$defs": {
+    "ros2Config": {
+      "type": "object",
+      "description": "ROS 2 runtime configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "domainId": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 232,
+          "description": "ROS_DOMAIN_ID — isolates ROS 2 nodes into independent communication domains. Valid range: 0–232."
+        },
+        "rmw": {
+          "type": "string",
+          "description": "ROS middleware implementation to use (e.g. \"cyclonedds\", \"fastrtps\").",
+          "examples": ["cyclonedds", "fastrtps"]
+        }
+      }
+    },
+    "runtimesConfig": {
+      "type": "object",
+      "description": "Runtime configuration for optional middleware or frameworks.",
+      "additionalProperties": false,
+      "properties": {
+        "ros2": {
+          "$ref": "#/$defs/ros2Config"
+        }
+      }
+    },
+    "serviceConfig": {
+      "type": "object",
+      "description": "Wendy-specific configuration for a single Docker Compose service.",
+      "additionalProperties": false,
+      "properties": {
+        "entitlements": {
+          "type": "array",
+          "description": "Hardware entitlements for this service. Appended after compose-synthesised entitlements (e.g. ports → network, named volumes → persist).",
+          "items": {
+            "$ref": "#/$defs/entitlement"
+          }
+        },
+        "runtimes": {
+          "$ref": "#/$defs/runtimesConfig",
+          "description": "Runtime configuration for this service. Overrides the top-level \"runtimes\" default."
+        }
+      }
+    },
     "entitlement": {
       "type": "object",
       "required": ["type"],


### PR DESCRIPTION
The CLI PR adds three new fields to `wendy.json` via `AppConfig`:

1. `isolation` (string) — e.g. `"shared-ipc"`, applied to every service in a compose group.
2. `runtimes` (object) — contains `ros2` with `domainId` (integer) and `rmw` (string); applies as a default to every service.
3. `services` (object map) — the compose-companion pattern: keys are Docker Compose service names, values have optional `entitlements` (array, same schema as top-level) and optional `runtimes` (overrides the top-level default for that service).

The extension ships `schemas/wendy-schema.json` which is registered as the JSON validator for `wendy.json` files. Without updating it, users writing companion `wendy.json` files will get spurious "unknown property" errors for `isolation`, `runtimes`, and `services` in VS Code, and won't get autocomplete/hover docs for those fields.

No TypeScript source files need changing — the container name separator change (`/` → `_`) and `AppContainer.services` proto field are internal to the agent and not surfaced by any extension code.
