### PR TITLE
chore(vscode): regenerate wendy.json schema from the CLI

### DIFF
--- a/schemas/wendy-schema.json
+++ b/schemas/wendy-schema.json
@@ -14,7 +14,9 @@
     "appId": {
       "type": "string",
       "minLength": 1,
-      "description": "Unique application identifier."
+      "maxLength": 253,
+      "pattern": "^[a-zA-Z0-9._-]+$",
+      "description": "Unique application identifier. Only letters, digits, '.', '_', and '-' are allowed."
     },
     "version": {
       "type": "string",
@@ -22,17 +24,8 @@
     },
     "platform": {
       "type": "string",
-      "oneOf": [
-        {
-          "enum": ["wendyos", "wendy-lite", "darwin"],
-          "description": "Named target platform: wendyos (Linux edge device running WendyOS), wendy-lite (ESP32 WASM target), or darwin (native macOS app via Wendy Agent for Mac)."
-        },
-        {
-          "pattern": "^linux\\/[a-zA-Z0-9_]+$",
-          "description": "Explicit Linux architecture target, e.g. linux/arm64 or linux/amd64."
-        }
-      ],
-      "description": "Target platform. One of: wendyos (Linux edge device running WendyOS), wendy-lite (ESP32 WASM target), darwin (native macOS app running through Wendy Agent for Mac), or a Linux architecture string such as linux/arm64 or linux/amd64. Omit to target the default platform. If the selected target is Wendy Agent for Mac, wendy run rejects any platform value that does not resolve to darwin."
+      "enum": ["wendyos", "wendy-lite", "darwin"],
+      "description": "Target platform: wendyos (Linux edge devices), wendy-lite (ESP32 WASM), or darwin (native macOS via Wendy Agent for Mac)."
     },
     "language": {
       "type": "string",
@@ -43,27 +36,11 @@
       "default": false,
       "description": "Enable debug mode."
     },
-    "isolation": {
-      "type": "string",
-      "enum": ["isolated", "shared-ipc", "shared-network"],
-      "description": "Isolation mode for multi-service apps. \"isolated\" gives each container its own CNI-assigned IP with /etc/hosts-based service discovery. \"shared-ipc\" shares IPC, network, and UTS namespaces plus /dev/shm between all services. \"shared-network\" shares network and UTS namespaces (suitable for ROS2 DDS multicast)."
-    },
-    "frameworks": {
-      "$ref": "#/$defs/frameworks",
-      "description": "Framework-specific configuration applied to all services unless overridden per-service."
-    },
     "entitlements": {
       "type": "array",
       "description": "Capabilities the app requires (GPU, network, Bluetooth, etc.).",
       "items": {
         "$ref": "#/$defs/entitlement"
-      }
-    },
-    "services": {
-      "type": "object",
-      "description": "Named services that make up a multi-container app group. Each key is the service name; the value describes how to build and configure that service. Note: multi-service wendy.json configs are not supported when the selected target is Wendy Agent for Mac.",
-      "additionalProperties": {
-        "$ref": "#/$defs/serviceDefinition"
       }
     },
     "readiness": {
@@ -87,64 +64,6 @@
     }
   },
   "$defs": {
-    "serviceDefinition": {
-      "type": "object",
-      "description": "Configuration for a single service within a multi-container app group.",
-      "additionalProperties": false,
-      "properties": {
-        "context": {
-          "type": "string",
-          "description": "Path to the build context directory (relative to wendy.json) used when building the service image."
-        },
-        "dependsOn": {
-          "type": "array",
-          "description": "Names of services that must start before this service. Wendy uses topological ordering so dependents stop before dependencies on shutdown.",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "uniqueItems": true
-        },
-        "entitlements": {
-          "type": "array",
-          "description": "Capabilities this specific service requires.",
-          "items": {
-            "$ref": "#/$defs/entitlement"
-          }
-        },
-        "frameworks": {
-          "$ref": "#/$defs/frameworks",
-          "description": "Framework-specific configuration for this service. Overrides any top-level frameworks config."
-        }
-      }
-    },
-    "frameworks": {
-      "type": "object",
-      "description": "Framework-specific runtime configuration.",
-      "additionalProperties": false,
-      "properties": {
-        "ros2": {
-          "$ref": "#/$defs/ros2Framework"
-        }
-      }
-    },
-    "ros2Framework": {
-      "type": "object",
-      "description": "ROS2 framework configuration. Wendy automatically injects ROS_DOMAIN_ID and RMW_IMPLEMENTATION environment variables into the container at start time.",
-      "additionalProperties": false,
-      "properties": {
-        "domainId": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 232,
-          "description": "ROS2 domain ID. Injected as the ROS_DOMAIN_ID environment variable."
-        },
-        "rmw": {
-          "type": "string",
-          "description": "ROS2 middleware implementation identifier. Injected as the RMW_IMPLEMENTATION environment variable (e.g. \"rmw_cyclonedds_cpp\", \"rmw_fastrtps_cpp\")."
-        }
-      }
-    },
     "entitlement": {
       "type": "object",
       "required": ["type"],
@@ -157,13 +76,6 @@
               "type": "string",
               "enum": ["host", "none"],
               "description": "Network mode. \"host\" shares the host network stack; \"none\" disables networking."
-            },
-            "ports": {
-              "type": "array",
-              "description": "Port mappings to expose from the container.",
-              "items": {
-                "$ref": "#/$defs/portMapping"
-              }
             }
           },
           "required": ["type"],
@@ -308,26 +220,6 @@
         }
       ]
     },
-    "portMapping": {
-      "type": "object",
-      "description": "A host-to-container port mapping.",
-      "required": ["host", "container"],
-      "additionalProperties": false,
-      "properties": {
-        "host": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535,
-          "description": "Port number on the host device."
-        },
-        "container": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535,
-          "description": "Port number inside the container."
-        }
-      }
-    },
     "readiness": {
       "type": "object",
       "description": "Probe configuration the CLI uses to determine when the app is ready.",
@@ -432,3 +324,4 @@
     }
   }
 }
+


### PR DESCRIPTION
The committed `schemas/wendy-schema.json` had drifted from the shipping CLI. It declared `isolation`, `frameworks`, `services`, `serviceDefinition`, `ros2Framework`, and `portMapping` — none of which `wendy json schema` (v2026.06.12) actually emits — so `wendy.json` authors got autocomplete and validation for fields the CLI rejects.

This replaces the file verbatim with the CLI's own schema output (the authoritative source the file is meant to mirror). It also picks up the real `appId` pattern/`maxLength` and the `platform` enum.

**Supersedes #35**, which proposed a *different* set of multi-service fields that were also divergent from the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)