### PR TITLE
feat(vscode): proposal for WendyOS#1035

### DIFF
--- a/package.json
+++ b/package.json
@@ -385,6 +385,17 @@
           "type": "string",
           "default": null,
           "description": "ID of the currently selected Wendy device"
+        },
+        "wendyos.audio.bufferMs": {
+          "type": "integer",
+          "default": 30,
+          "minimum": 0,
+          "description": "Playback jitter-buffer target latency in milliseconds for 'wendy device audio listen'. Lower values reduce latency but risk dropouts."
+        },
+        "wendyos.audio.allDevices": {
+          "type": "boolean",
+          "default": false,
+          "description": "Include virtual/dummy capture devices (e.g. Tegra ADMAIF, HDMI) in the audio auto-selection pool when running 'wendy device audio listen'."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -850,6 +850,15 @@ export async function activate(
           args.push('--id', match[1]);
         }
 
+        const audioConfig = vscode.workspace.getConfiguration("wendyos.audio");
+        const bufferMs = audioConfig.get<number>("bufferMs", 30);
+        if (typeof bufferMs === "number" && bufferMs !== 30) {
+          args.push('--buffer-ms', String(bufferMs));
+        }
+        if (audioConfig.get<boolean>("allDevices", false)) {
+          args.push('--all');
+        }
+
         const label = item.hardware.description || item.hardware.devicePath || 'Audio';
         const terminal = vscode.window.createTerminal({
           name: `Audio: ${label}`,


### PR DESCRIPTION
The CLI's `wendy device audio listen` command gained two new flags in this PR:

- `--buffer-ms <uint32>` (default 30): controls the playback jitter-buffer target latency in milliseconds. Lower values reduce latency but risk dropouts.
- `--all` (bool): includes virtual/dummy capture devices (e.g. Tegra ADMAIF, HDMI) in the auto-selection pool, which are otherwise filtered out.

The VSCode extension already registers a `wendyHardware.listenAudioInput` command that invokes `wendy device audio listen`. To let users control these new knobs from VS Code settings (rather than requiring them to use the CLI directly), two new configuration properties should be added to `package.json`: `wendyos.audio.bufferMs` (integer, default 30) and `wendyos.audio.allDevices` (boolean, default false). The `HardwareProvider.ts` sidebar provider must also be updated to read these settings and pass `--buffer-ms` and `--all` when spawning the terminal for the listen command.
