### PR TITLE
feat(vscode): proposal for WendyOS#1060

### DIFF
--- a/src/sidebar/DevicesProvider.ts
+++ b/src/sidebar/DevicesProvider.ts
@@ -7,6 +7,7 @@ function formatDeviceType(raw: string): string {
   if (s.startsWith("raspberrypi5")) { return "Raspberry Pi 5"; }
   if (s.startsWith("raspberrypi4")) { return "Raspberry Pi 4"; }
   if (s.startsWith("raspberrypi3")) { return "Raspberry Pi 3"; }
+  if (s.startsWith("jetson-agx-thor")) { return "Jetson AGX Thor"; }
   if (s.startsWith("jetson-agx-orin")) { return "Jetson AGX Orin"; }
   if (s.startsWith("jetson-orin-nx")) { return "Jetson Orin NX"; }
   if (s.startsWith("jetson-orin-nano")) { return "Jetson Orin Nano"; }


### PR DESCRIPTION
The CLI PR adds `"jetson-agx-thor"` → `"Jetson AGX Thor"` to its `deviceTypeNames` display map (`discover.go`) and maps that device type to the `nvidia-jetson` platform tier (`run.go`). The VSCode extension has its own `formatDeviceType` function in `src/sidebar/DevicesProvider.ts` that independently maps raw device-type strings to human-readable labels shown in the Devices sidebar tree. It currently has no entry for `jetson-agx-thor`, so a Thor device would fall through and display its raw identifier instead of "Jetson AGX Thor". A new `startsWith("jetson-agx-thor")` branch needs to be added, placed before the existing `jetson-agx-orin` check to ensure correct prefix matching.
