### PR TITLE
feat(vscode): proposal for WendyOS#1133

### DIFF
--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -8,6 +8,12 @@ export class Device {
    */
   public deviceType: string | undefined;
 
+  /**
+   * GPU architecture identifier reported by `wendy device info` (e.g. "sm_87" for NVIDIA Ampere).
+   * Vendor-specific format. Populated asynchronously after the device is discovered.
+   */
+  public gpuArch: string | undefined;
+
   constructor(
     /**
      * Unique identifier for the device

--- a/src/models/DeviceManager.ts
+++ b/src/models/DeviceManager.ts
@@ -89,6 +89,11 @@ export interface DeviceInfo {
   currentVersion: string;
   latestVersion: string | undefined;
   deviceType?: string;
+  /**
+   * GPU architecture identifier (e.g. "sm_87" for NVIDIA Ampere).
+   * Vendor-specific format. Present only when the device has a detected GPU.
+   */
+  gpuArch?: string;
 }
 
 export interface WifiConnectionResult {
@@ -382,10 +387,20 @@ export class DeviceManager implements vscode.Disposable {
     });
 
     const info: DeviceInfo = JSON.parse(output);
+    let changed = false;
+
     if (info.deviceType) {
       device.deviceType = info.deviceType;
+      changed = true;
+    }
+    if (info.gpuArch) {
+      device.gpuArch = info.gpuArch;
+      changed = true;
+    }
+    if (changed) {
       this._onDevicesChanged.fire();
     }
+
     if (info.latestVersion) {
       const confirmed = await vscode.window.showInformationMessage(
         `Update available for ${device.name}: ${info.latestVersion}`,


### PR DESCRIPTION
The CLI's `wendy device info --json` output now includes an optional `gpuArch` field (e.g. `"gpuArch": "sm_87"`) in the JSON response, populated for NVIDIA devices via `nvidia-smi`. The extension should:

1. Add `gpuArch?: string` to the `DeviceInfo` interface in `DeviceManager.ts` so the parsed JSON is typed correctly.
2. Add a `gpuArch` property to the `Device` model (mirroring how `deviceType` is stored and propagated after `checkForUpdates` parses the device info JSON).
3. Propagate `gpuArch` from the `DeviceInfo` result into the `Device` instance inside `checkForUpdates`, the same way `deviceType` is already handled.
