### PR TITLE
feat(vscode): proposal for WendyOS#1147

### DIFF
--- a/schemas/wendy-schema.json
+++ b/schemas/wendy-schema.json
@@ -24,8 +24,17 @@
     },
     "platform": {
       "type": "string",
-      "enum": ["wendyos", "wendy-lite", "darwin"],
-      "description": "Target platform: wendyos (Linux edge devices), wendy-lite (ESP32 WASM), or darwin (native macOS via Wendy Agent for Mac)."
+      "enum": [
+        "linux",
+        "wendyos",
+        "wendy-lite",
+        "darwin",
+        "linux/arm64",
+        "linux/amd64",
+        "linux/arm/v7",
+        "linux/arm/v6"
+      ],
+      "description": "Target platform. Use \"linux\" for WendyOS/Linux container targets (device architecture is inferred). \"wendyos\" is a compatibility alias for \"linux\". \"wendy-lite\" targets ESP32 WASM. \"darwin\" targets native macOS apps running through Wendy for Mac. Explicit architecture strings such as \"linux/arm64\" or \"linux/amd64\" are also accepted."
     },
     "language": {
       "type": "string",


### PR DESCRIPTION
The CLI PR changes the default `platform` value in `wendy.json` from `wendyos` to `linux`. The docs now define:
- `"linux"` as the primary value for Linux edge device targets (architecture inferred)
- `"wendyos"` as a compatibility alias for `"linux"`
- `"wendy-lite"`, `"darwin"`, and explicit `"linux/arm64"`, `"linux/amd64"` etc. remain valid

The extension's `schemas/wendy-schema.json` currently lists the `platform` enum as `["wendyos", "wendy-lite", "darwin"]`, which omits `"linux"` entirely and will cause JSON validation errors for any `wendy.json` that uses the new default. The schema needs to be updated to add `"linux"` (and the explicit architecture variants) to the enum, reorder so `"linux"` appears first, and update the description to match the new documentation.
