### PR TITLE
feat(vscode): proposal for WendyOS#1071

### DIFF
--- a/schemas/wendy-schema.json
+++ b/schemas/wendy-schema.json
@@ -36,6 +36,12 @@
       "default": false,
       "description": "Enable debug mode."
     },
+    "brewfile": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?:\\./)?(?!/)(?!.*[\\\\%\\u0000-\\u001F])(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*(?:/)\\.(?:/|$))(?!.*//)(?!.*/$).+$",
+      "description": "Optional Homebrew Bundle manifest for native Darwin (platform: \"darwin\") deployments. The path is relative to wendy.json; absolute paths and '..' components are not allowed. If omitted, a project-root Brewfile.wendy is auto-detected for native SwiftPM and Xcode Mac runs. The CLI syncs the Brewfile to the target Mac and Wendy Agent runs `brew bundle --file <synced Brewfile>` before starting the app. Homebrew must already be installed on the target Mac. Linux/WendyOS container deployments ignore this field."
+    },
     "isolation": {
       "type": "string",
       "enum": ["shared-network", "shared-ipc"],


### PR DESCRIPTION
The CLI PR adds a new optional `brewfile` field to `wendy.json` for native Darwin deployments. The field is defined in the CLI's own JSON Schema (`wendy.schema.json`) with a type, pattern, minLength, and description. The VSCode extension maintains its own copy of the wendy.json schema at `schemas/wendy-schema.json` that drives editor validation and autocomplete for users editing `wendy.json`. The extension schema needs the `brewfile` property added to its top-level `properties` object, matching the CLI schema's definition, so that users editing `wendy.json` in VS Code get proper IntelliSense, inline documentation, and validation for the new field.
