### PR TITLE
feat(vscode): proposal for WendyOS#1202

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,16 @@
         "category": "Wendy"
       },
       {
+        "command": "wendy.optimizeProject",
+        "title": "Optimize Project",
+        "category": "Wendy"
+      },
+      {
+        "command": "wendy.optimizeProjectFix",
+        "title": "Optimize Project (Apply Fixes)",
+        "category": "Wendy"
+      },
+      {
         "command": "wendy.analyticsStatus",
         "title": "Analytics Status",
         "category": "Wendy"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,6 +95,41 @@ export async function activate(
       vscode.window.setStatusBarMessage(`Copied ${label}`, 2000);
     };
 
+    const runProjectOptimize = async (fix: boolean): Promise<void> => {
+      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+      if (!workspaceFolder) {
+        vscode.window.showErrorMessage("No workspace folder open");
+        return;
+      }
+
+      try {
+        const output = await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: fix
+              ? "Optimizing Wendy project (applying fixes)…"
+              : "Analyzing Wendy project for optimizations…",
+            cancellable: false,
+          },
+          async () => projectManager.optimizeProject(workspaceFolder.uri.fsPath, { fix })
+        );
+
+        outputChannel.show(true);
+        if (output.trim()) {
+          outputChannel.appendLine(output);
+        }
+        vscode.window.showInformationMessage(
+          fix
+            ? "Project optimization complete. See the WendyOS output for applied fixes."
+            : "Project optimization analysis complete. See the WendyOS output for findings."
+        );
+      } catch (error) {
+        vscode.window.showErrorMessage(
+          `Failed to optimize project: ${getErrorDescription(error)}`
+        );
+      }
+    };
+
     const createDeviceInfoHtml = (
       deviceItem: DeviceTreeItem,
       deviceDetails: LANDevice | undefined
@@ -955,6 +990,16 @@ export async function activate(
             `Failed to build project: ${getErrorDescription(error)}`
           );
         }
+      }),
+
+      // Analyze the project for missed build optimizations.
+      vscode.commands.registerCommand("wendy.optimizeProject", async () => {
+        await runProjectOptimize(false);
+      }),
+
+      // Analyze and apply safe, deterministic fixes.
+      vscode.commands.registerCommand("wendy.optimizeProjectFix", async () => {
+        await runProjectOptimize(true);
       }),
 
       // Manage entitlements command

--- a/src/models/ProjectManager.ts
+++ b/src/models/ProjectManager.ts
@@ -19,6 +19,19 @@ export interface EntitlementOptions {
   path?: string;
 }
 
+export type OptimizeSeverity = "info" | "warning" | "error";
+
+export interface OptimizeProjectOptions {
+  /** Apply safe, deterministic fixes (cache mount, .dockerignore, release flag). */
+  fix?: boolean;
+  /** Force JSON output regardless of TTY state. */
+  json?: boolean;
+  /** Minimum severity that triggers a non-zero exit code. Defaults to "warning". */
+  severity?: OptimizeSeverity;
+  /** Target architecture override. Defaults to arm64 in the CLI. */
+  arch?: string;
+}
+
 export interface BuildProjectOptions {
   /** Specific Dockerfile to build from (e.g. "Dockerfile.prod"). When omitted,
    *  the CLI will auto-detect or show an interactive picker. */
@@ -137,6 +150,64 @@ export class ProjectManager {
         }
         this.outputChannel.appendLine(stdout);
         resolve();
+      });
+    });
+  }
+
+  /**
+   * Statically analyze a project's build configuration for missed
+   * optimizations via `wendy project optimize`, returning the command's raw
+   * stdout (JSON or human-readable text depending on `options.json`).
+   *
+   * The CLI exits 0 (no findings), 1 (findings at or above the severity
+   * threshold), or 2 (error). Exit code 1 is not a failure from the
+   * extension's perspective — the findings are surfaced to the user — so it
+   * resolves with the stdout rather than rejecting.
+   */
+  async optimizeProject(
+    projectPath: string,
+    options: OptimizeProjectOptions = {}
+  ): Promise<string> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    const args: string[] = ['project', 'optimize'];
+    if (options.json) {
+      args.push('--json');
+    }
+    if (options.fix) {
+      args.push('--fix');
+    }
+    if (options.severity) {
+      args.push('--severity', options.severity);
+    }
+    if (options.arch) {
+      args.push('--arch', options.arch);
+    }
+
+    this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(' ')}`);
+
+    return new Promise((resolve, reject) => {
+      execFile(cli.path, args, { cwd: projectPath }, (error, stdout, stderr) => {
+        if (error) {
+          // execFile sets error.code to the process exit code for non-zero
+          // exits. Exit code 1 means findings were reported above the
+          // threshold — surface the output instead of treating it as an error.
+          const code = (error as NodeJS.ErrnoException & { code?: number }).code;
+          if (code === 1 && stdout) {
+            this.outputChannel.appendLine(stdout);
+            resolve(stdout);
+            return;
+          }
+          const msg = stderr || error.message;
+          this.outputChannel.appendLine(`Error: ${msg}`);
+          reject(new Error(msg));
+          return;
+        }
+        this.outputChannel.appendLine(stdout);
+        resolve(stdout);
       });
     });
   }


### PR DESCRIPTION
The CLI PR adds `wendy project optimize` — a new subcommand under `wendy project` that statically analyzes a project's build configuration for missed optimizations. It supports `--fix` (apply safe deterministic fixes), `--agentic` (emit a context bundle), `--json`, `--severity <info|warning|error>`, and `--arch` flags, and exits 0 (no findings), 1 (findings ≥ threshold), or 2 (error).

The extension should expose this command so developers can invoke it from VS Code's command palette without switching to the terminal. Specifically:

1. **`ProjectManager.ts`**: Add an `optimizeProject` method that wraps `wendy project optimize`, accepting an options bag for `--fix`, `--json`, `--severity`, and `--arch`, and returning the raw stdout (JSON or human text).
2. **`package.json`**: Register a `wendy.optimizeProject` palette command and a `wendy.optimizeProjectFix` palette command (for the common `--fix` variant).
3. **`extension.ts`**: Register both commands — `wendy.optimizeProject` runs the analyzer and surfaces findings in the output channel; `wendy.optimizeProjectFix` also passes `--fix` and reports applied fixes.
