### PR TITLE
feat(vscode): proposal for WendyOS#1215

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,12 @@
         "category": "Wendy"
       },
       {
+        "command": "wendyDevices.renameDevice",
+        "title": "Rename Device",
+        "icon": "$(edit)",
+        "category": "Wendy"
+      },
+      {
         "command": "wendyApps.showLogs",
         "title": "Show Logs",
         "category": "Wendy"
@@ -311,6 +317,11 @@
           "command": "wendyDevices.deviceSetup",
           "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
           "group": "device@1"
+        },
+        {
+          "command": "wendyDevices.renameDevice",
+          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
+          "group": "inline"
         },
         {
           "command": "wendyDevices.unenrollDevice",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -472,6 +472,89 @@ export async function activate(
       ),
 
       vscode.commands.registerCommand(
+        "wendyDevices.renameDevice",
+        async (item: DeviceTreeItem | undefined) => {
+          const targetItem = getTargetDeviceTreeItem(item);
+          if (!targetItem?.device) {
+            vscode.window.showErrorMessage(
+              "No device selected. Select a device in the Devices panel first."
+            );
+            return;
+          }
+
+          const device = targetItem.device;
+
+          // Mirrors the CLI's DNS-label validation:
+          // ^[a-z][a-z0-9-]{0,62}$ with no trailing hyphen.
+          const validateDeviceName = (value: string): string | undefined => {
+            if (!value) {
+              return "Name cannot be empty.";
+            }
+            if (value.length > 63) {
+              return "Name must be at most 63 characters.";
+            }
+            if (!/^[a-z][a-z0-9-]{0,62}$/.test(value)) {
+              return "Name must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.";
+            }
+            if (value.endsWith("-")) {
+              return "Name cannot end with a hyphen.";
+            }
+            return undefined;
+          };
+
+          const name = await vscode.window.showInputBox({
+            title: "Rename Device",
+            prompt:
+              "New device name — sets the hostname and mDNS name on the device, and the asset name in Wendy Cloud.",
+            value: "wendyos-",
+            valueSelection: [8, 8],
+            placeHolder: "wendyos-living-room",
+            validateInput: (value) => validateDeviceName(value.trim()) ?? null,
+          });
+
+          if (!name) {
+            return;
+          }
+
+          const trimmedName = name.trim();
+          const validationError = validateDeviceName(trimmedName);
+          if (validationError) {
+            vscode.window.showErrorMessage(`Invalid device name: ${validationError}`);
+            return;
+          }
+
+          const cli = await WendyCLI.create();
+          if (!cli) {
+            vscode.window.showErrorMessage(
+              "Wendy CLI is not available. Please check your installation."
+            );
+            return;
+          }
+
+          await vscode.window.withProgress(
+            {
+              location: vscode.ProgressLocation.Notification,
+              title: `Renaming device to "${trimmedName}"…`,
+              cancellable: false,
+            },
+            async () => {
+              try {
+                await cli.renameDevice(device.address, trimmedName);
+                vscode.window.showInformationMessage(
+                  `Device renamed to "${trimmedName}" (mDNS: ${trimmedName}.local).`
+                );
+                devicesProvider.refresh();
+              } catch (error) {
+                vscode.window.showErrorMessage(
+                  `Failed to rename device: ${getErrorDescription(error)}`
+                );
+              }
+            }
+          );
+        }
+      ),
+
+      vscode.commands.registerCommand(
         "wendyDevices.connectWifi",
         async (item) => {
           if (item?.device) {

--- a/src/wendy-cli/wendy-cli.ts
+++ b/src/wendy-cli/wendy-cli.ts
@@ -130,6 +130,26 @@ export class WendyCLI {
     }
     await this.exec(args);
   }
+
+  /**
+   * Renames a device, updating its hostname/mDNS name on the device and its
+   * asset name in Wendy Cloud. Optionally overrides the cloud gRPC endpoint.
+   *
+   * @param deviceAddress Address (hostname or hostname:port) of the device to rename.
+   * @param name New device name (a DNS label, e.g. `wendyos-living-room`).
+   * @param cloudGRPC Optional cloud gRPC endpoint override.
+   */
+  public async renameDevice(
+    deviceAddress: string,
+    name: string,
+    cloudGRPC?: string
+  ): Promise<void> {
+    const args = ["device", "rename", name, "--device", deviceAddress];
+    if (cloudGRPC && cloudGRPC.trim() !== "") {
+      args.push("--cloud-grpc", cloudGRPC.trim());
+    }
+    await this.exec(args);
+  }
 }
 
 export interface WendyInfo {


### PR DESCRIPTION
The CLI gained `wendy device rename [name]` (PR #1215), which renames a device's hostname/mDNS name on the device and its asset name in Wendy Cloud. The extension should expose this as:

1. A `renameDevice(deviceAddress, name, cloudGRPC?)` method on `WendyCLI`, mirroring the existing `unenrollDevice` wrapper.
2. A `wendyDevices.renameDevice` VS Code command registered in `extension.ts` that: prompts the user for a new name (pre-filled with `wendyos-`), validates it as a DNS label (matching the CLI's `^[a-z][a-z0-9-]{0,62}$`, no trailing hyphen rule), invokes the CLI, and refreshes the Devices tree.
3. A command + inline `view/item/context` menu entry in `package.json` so the action appears on device tree items in the Devices panel.
