### PR TITLE
feat(vscode): proposal for WendyOS#1303

### DIFF
--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -1,4 +1,14 @@
 /**
+ * A single network interface reported by `wendy device info`.
+ */
+export interface NetworkInterface {
+  /** Interface name (e.g. "eth0", "wlan0"). */
+  name: string;
+  /** Routable IPv4 and IPv6 addresses assigned to the interface. */
+  ipAddresses: string[];
+}
+
+/**
  * Represents a Wendy device that can be connected to.
  */
 export class Device {
@@ -13,6 +23,14 @@ export class Device {
    * Vendor-specific format. Populated asynchronously after the device is discovered.
    */
   public gpuArch: string | undefined;
+
+  /**
+   * Routable network interfaces reported by `wendy device info`.
+   * Loopback, down, and container/virtual bridge interfaces are omitted.
+   * Populated asynchronously after the device is discovered. Empty or undefined
+   * when the agent does not support network interface enumeration.
+   */
+  public networkInterfaces: NetworkInterface[] | undefined;
 
   constructor(
     /**
@@ -40,4 +58,28 @@ export class Device {
      */
     public readonly connectionType: "Ethernet" | "USB" | "LAN" | "BLE" | "Docker" | "Local" | "External" | "Custom"
   ) {}
+
+  /**
+   * Returns the best routable IP address for this device, preferring IPv4 over
+   * IPv6, across all reported network interfaces. Returns undefined when no
+   * routable address is known. Mirrors the `bestReachableIP` logic in the CLI.
+   */
+  public bestReachableIP(): string | undefined {
+    if (!this.networkInterfaces || this.networkInterfaces.length === 0) {
+      return undefined;
+    }
+    let firstAny: string | undefined;
+    for (const iface of this.networkInterfaces) {
+      for (const addr of iface.ipAddresses) {
+        // Simple IPv4 detection: contains a dot and no colon.
+        if (addr.includes(".") && !addr.includes(":")) {
+          return addr;
+        }
+        if (firstAny === undefined) {
+          firstAny = addr;
+        }
+      }
+    }
+    return firstAny;
+  }
 }


### PR DESCRIPTION
The CLI's `wendy device info --json` output now includes a `networkInterfaces` array (each entry has `name` and `ipAddresses` fields) alongside the existing fields like `deviceType` and `gpuArch`. The extension's `Device` model should be updated to store this new data so it can be surfaced in the sidebar (e.g. in tooltips or tree item descriptions), mirroring how `deviceType` and `gpuArch` are already stored and populated from the same JSON output.
