### PR TITLE
feat(vscode): proposal for WendyOS#1317

### DIFF
--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -25,6 +25,20 @@ export class Device {
   public gpuArch: string | undefined;
 
   /**
+   * Number of online logical CPU cores reported by `wendy device info`.
+   * Populated asynchronously after the device is discovered. Undefined when
+   * the agent did not report it (older agents or non-Linux hosts).
+   */
+  public cpuCount: number | undefined;
+
+  /**
+   * Total physical RAM in bytes reported by `wendy device info`.
+   * Populated asynchronously after the device is discovered. Undefined when
+   * the agent did not report it (older agents or non-Linux hosts).
+   */
+  public memTotalBytes: number | undefined;
+
+  /**
    * Routable network interfaces reported by `wendy device info`.
    * Loopback, down, and container/virtual bridge interfaces are omitted.
    * Populated asynchronously after the device is discovered. Empty or undefined

--- a/src/models/DeviceManager.ts
+++ b/src/models/DeviceManager.ts
@@ -94,6 +94,16 @@ export interface DeviceInfo {
    * Vendor-specific format. Present only when the device has a detected GPU.
    */
   gpuArch?: string;
+  /**
+   * Number of online logical CPU cores. Present only when the agent reports it
+   * (requires a recent agent on a Linux host). Zero means unknown.
+   */
+  cpuCount?: number;
+  /**
+   * Total physical RAM in bytes. Present only when the agent reports it
+   * (requires a recent agent on a Linux host). Zero means unknown.
+   */
+  memTotalBytes?: number;
 }
 
 export interface WifiConnectionResult {
@@ -395,6 +405,16 @@ export class DeviceManager implements vscode.Disposable {
     }
     if (info.gpuArch) {
       device.gpuArch = info.gpuArch;
+      changed = true;
+    }
+    // cpuCount and memTotalBytes are omitted from JSON when zero/unknown; only
+    // set them when the agent reported a real value (> 0).
+    if (info.cpuCount && info.cpuCount > 0) {
+      device.cpuCount = info.cpuCount;
+      changed = true;
+    }
+    if (info.memTotalBytes && info.memTotalBytes > 0) {
+      device.memTotalBytes = info.memTotalBytes;
       changed = true;
     }
     if (changed) {


### PR DESCRIPTION
`wendy device info --json` now includes two new optional fields: `cpuCount` (number of logical CPU cores) and `memTotalBytes` (total physical RAM in bytes). Both are omitted when the agent cannot read them (zero on the wire). The extension's `DeviceInfo` interface and `Device` model should be extended to carry these fields (matching the existing pattern for `gpuArch`/`deviceType`), and `checkForUpdates` should populate them so the rest of the extension (e.g. tree-item tooltips) can use them.
