### PR TITLE
feat(vscode): proposal for WendyOS#1341

### DIFF
--- a/src/models/DeviceManager.ts
+++ b/src/models/DeviceManager.ts
@@ -1,860 +1,410 @@
 import * as vscode from "vscode";
-import { Device } from "./Device";
-import { v7 as uuidv7 } from "uuid";
 import { execFile } from "child_process";
 import { WendyCLI } from "../wendy-cli/wendy-cli";
 import { analyticsDisabledEnv } from "../utilities/utilities";
 
-export interface EthernetDevice {
-  displayName: string;
-  isWendyOSDevice: boolean;
-  macAddress: string;
+export interface AppInfo {
+  appName: string;
+  runningState: AppRunningState;
+  failureCount?: number;
+  exitCode?: number;
+  terminationReason?: string;
+  services?: ServiceEntry[];
+}
+
+/**
+ * Running state of an app on a WendyOS device.
+ *
+ * - RUNNING: the app is actively running.
+ * - STOPPED: the app is not running (clean stop or first exit before any restart).
+ * - CRASH_LOOPING: the app is not running right now but the agent's restart
+ *   policy is actively restarting it — it has already been auto-restarted at
+ *   least once and will be started again (WDY-1826 / CLI PR #1341).
+ */
+export type AppRunningState = "RUNNING" | "STOPPED" | "CRASH_LOOPING";
+
+export interface ServiceEntry {
   name: string;
-}
-
-export interface USBDevice {
-  isWendyOSDevice: boolean;
-  productId: string;
-  vendorId: string;
-  name: string;
-}
-
-export interface LANDevice {
-  displayName: string;
-  id: string;
-  hostname: string;
-  port: number;
-  agentVersion: string | undefined;
-  deviceType?: string;
-  interfaceType?: string;
-  isWendyDevice?: boolean;
-  /**
-   * Non-empty when the device is reachable over a USB/Ethernet-gadget interface.
-   * Mirrors the `usb` field added to LAN device entries in `wendy discover --json`.
-   * Example value: "enp0s20f0u9 480 Mbps"
-   */
-  usb?: string;
-  apps?: LANDeviceApp[];
-}
-
-export interface LANDeviceApp {
-  name: string;
-  version?: string;
-  bundleIdentifier?: string;
-}
-
-export interface BluetoothDevice {
-    id: string;
-    displayName: string;
-    address: string;
-    rssi: number;
-    isWendyDevice: boolean;
-    agentVersion?: string;
-    os?: string;
-    osVersion?: string;
-    cpuArchitecture?: string;
-    featureset?: Set<string>;
-    l2capPSM?: number;
-}
-
-export interface ExternalDevice {
-  id: string;
-  displayName: string;
-  os?: string;
-  cpuArchitecture?: string;
-  isWendyDevice?: boolean;
-  agentVersion?: string;
-  providerKey?: string;
-  connectionInfo?: Record<string, string>;
-}
-
-export interface DeviceList {
-  lanDevices: LANDevice[] | null;
-  ethernetDevices: EthernetDevice[] | null;
-  usbDevices: USBDevice[] | null;
-  bluetoothDevices: BluetoothDevice[] | null;
-  externalDevices: ExternalDevice[] | null;
-}
-
-export interface WifiNetwork {
-  ssid: string;
-  signalStrength: number;
+  runningState: AppRunningState;
+  failureCount?: number;
+  exitCode?: number;
+  terminationReason?: string;
 }
 
 export interface WifiStatus {
   connected: boolean;
-  ssid: string;
+  ssid?: string;
+  ipAddress?: string;
 }
 
-export interface DeviceInfo {
+export interface UpdateInfo {
   currentVersion: string;
-  latestVersion: string | undefined;
-  deviceType?: string;
-  /**
-   * GPU architecture identifier (e.g. "sm_87" for NVIDIA Ampere).
-   * Vendor-specific format. Present only when the device has a detected GPU.
-   */
-  gpuArch?: string;
-  /**
-   * Number of online logical CPU cores. Present only when the agent reports it
-   * (requires a recent agent on a Linux host). Zero means unknown.
-   */
-  cpuCount?: number;
-  /**
-   * Total physical RAM in bytes. Present only when the agent reports it
-   * (requires a recent agent on a Linux host). Zero means unknown.
-   */
-  memTotalBytes?: number;
-}
-
-export interface WifiConnectionResult {
-  success: boolean;
-}
-
-export interface DeviceApp {
-  name: string;
-  version?: string;
-  runningState?: string;
-  failureCount?: number;
+  latestVersion: string;
+  updateAvailable: boolean;
 }
 
 export interface HardwareDevice {
+  id: string;
+  name: string;
   category: string;
-  description?: string;
   devicePath?: string;
-  properties?: Record<string, string>;
 }
 
-export type HardwareCategory = 'gpu' | 'usb' | 'i2c' | 'spi' | 'gpio' | 'camera' | 'audio' | 'input' | 'serial' | 'network' | 'storage';
+/**
+ * A single network interface reported by `wendy device info`.
+ */
+export interface NetworkInterface {
+  name: string;
+  ipAddresses: string[];
+}
 
 /**
- * Manages devices stored in VS Code configuration
+ * Manages interactions with a Wendy device via the CLI.
  */
-export class DeviceManager implements vscode.Disposable {
-  private static readonly CONFIG_KEY = "wendyos.devices";
-  private static readonly CURRENT_DEVICE_KEY = "wendyos.currentDevice";
-  private _onDevicesChanged = new vscode.EventEmitter<void>();
-  private devices: Device[] = [];
-  private deviceIdsCheckedForUpdates: Set<string> = new Set();
-  private currentDevice: Device | undefined;
-  private lanDeviceDetails: Map<string, LANDevice> = new Map();
-  // Discovery is split into a fast loop (LAN — real edge devices, ~1s) and a
-  // slow loop (Bluetooth + external providers, which take several seconds and
-  // change rarely) so LAN devices appear quickly instead of waiting for the
-  // full all-types scan. Results are cached per loop and merged on rebuild.
-  private fastDiscoveryTimer: ReturnType<typeof setTimeout> | undefined;
-  private slowDiscoveryTimer: ReturnType<typeof setTimeout> | undefined;
-  private fastDiscoveredDevices: Device[] = [];
-  private slowDiscoveredDevices: Device[] = [];
-  private disposed: boolean = false;
-  readonly onDevicesChanged = this._onDevicesChanged.event;
-
-  private _onCurrentDeviceChanged = new vscode.EventEmitter<
-    string | undefined
-  >();
-  readonly onCurrentDeviceChanged = this._onCurrentDeviceChanged.event;
-
-  constructor() {
-    this.devices = this.getManualDevices();
-  }
-
-  private getManualDevices(): Device[] {
-    const config = vscode.workspace.getConfiguration();
-    const devices =
-      config.get<Array<{ id: string; address: string }>>(
-        DeviceManager.CONFIG_KEY
-      ) || [];
-    return devices.map((d) => new Device(
-      d.id,
-      d.address,
-      d.address,
-      undefined,
-      "Custom"
-    ));
-  }
+export class DeviceManager {
+  constructor(private outputChannel: vscode.OutputChannel) {}
 
   /**
-   * Start periodic device discovery using `wendy discover --json`.
-   *
-   * Two independent loops run concurrently so the common case is fast: a
-   * fast loop scans LAN (real edge devices, ~1s) and a slow loop scans
-   * Bluetooth + external providers (several seconds, and they change rarely).
-   * Each loop caches its own results; the merged list is rebuilt and emitted
-   * after every scan, so LAN devices show up without waiting on Bluetooth.
+   * Lists apps on the device.
+   * Background call — analytics disabled.
    */
-  async startDiscovery(): Promise<void> {
-    this.stopDiscovery();
-
+  async listApps(deviceAddress: string): Promise<AppInfo[]> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      return;
+      throw new Error("Wendy CLI not found");
     }
 
-    void this.runFastDiscovery(cli);
-    void this.runSlowDiscovery(cli);
-  }
+    return new Promise((resolve, reject) => {
+      const args = ["--json", "device", "apps", "list", "--device", deviceAddress];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
 
-  private async runFastDiscovery(cli: WendyCLI): Promise<void> {
-    const list = await this.scanType(cli, "lan", "1s");
-    if (list) {
-      const nextLanDeviceDetails = new Map<string, LANDevice>();
-      const devices: Device[] = [];
-      for (const lanDevice of list.lanDevices || []) {
-        nextLanDeviceDetails.set(lanDevice.id, lanDevice);
-        const device = new Device(
-          lanDevice.id,
-          lanDevice.hostname,
-          lanDevice.displayName,
-          lanDevice.agentVersion,
-          "LAN"
-        );
-        if (lanDevice.deviceType) {
-          device.deviceType = lanDevice.deviceType;
-        }
-        devices.push(device);
-      }
-      this.lanDeviceDetails = nextLanDeviceDetails;
-      this.fastDiscoveredDevices = devices;
-      this.rebuildDevices();
-    }
-
-    if (!this.disposed) {
-      this.fastDiscoveryTimer = setTimeout(
-        () => void this.runFastDiscovery(cli),
-        2000
-      );
-    }
-  }
-
-  private async runSlowDiscovery(cli: WendyCLI): Promise<void> {
-    const [bluetooth, external] = await Promise.all([
-      this.scanType(cli, "bluetooth", "5s"),
-      this.scanType(cli, "external", "2s"),
-    ]);
-
-    if (bluetooth || external) {
-      const devices: Device[] = [];
-      for (const btDevice of bluetooth?.bluetoothDevices || []) {
-        devices.push(new Device(
-          btDevice.id,
-          btDevice.address,
-          btDevice.displayName,
-          btDevice.agentVersion,
-          "BLE"
-        ));
-      }
-      for (const externalDevice of external?.externalDevices || []) {
-        const connectionType = this.connectionTypeForExternalDevice(externalDevice);
-        devices.push(new Device(
-          externalDevice.id,
-          externalDevice.id,
-          externalDevice.displayName,
-          externalDevice.agentVersion,
-          connectionType
-        ));
-      }
-      this.slowDiscoveredDevices = devices;
-      this.rebuildDevices();
-    }
-
-    if (!this.disposed) {
-      this.slowDiscoveryTimer = setTimeout(
-        () => void this.runSlowDiscovery(cli),
-        10000
-      );
-    }
-  }
-
-  /**
-   * Runs a single `wendy discover` scan for one device type and returns the
-   * parsed result, or null if the scan failed or produced no usable output.
-   */
-  private scanType(
-    cli: WendyCLI,
-    type: string,
-    timeout: string
-  ): Promise<DeviceList | null> {
-    return new Promise((resolve) => {
       execFile(
         cli.path,
-        ["discover", "--json", "--type", type, "--timeout", timeout],
+        args,
         { env: analyticsDisabledEnv() },
         (error, stdout, stderr) => {
-          if (stderr) {
-            console.error(`Device discovery (${type}) stderr:`, stderr);
+          if (error) {
+            this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
+            reject(new Error(stderr || error.message));
+            return;
           }
-          if (!error && stdout.trim()) {
-            try {
-              resolve(JSON.parse(stdout) as DeviceList);
-              return;
-            } catch (e) {
-              console.error(`Failed to parse ${type} discovery output:`, e);
-            }
+          try {
+            const apps = JSON.parse(stdout);
+            resolve(Array.isArray(apps) ? apps : []);
+          } catch {
+            resolve([]);
           }
-          resolve(null);
         }
       );
     });
   }
 
   /**
-   * Merges the fast (LAN) and slow (Bluetooth/external) discovery caches with
-   * manually configured devices, de-duplicating by id, and notifies listeners.
-   */
-  private rebuildDevices(): void {
-    const merged: Device[] = [];
-    const seen = new Set<string>();
-    for (const device of [
-      ...this.fastDiscoveredDevices,
-      ...this.slowDiscoveredDevices,
-      ...this.getManualDevices(),
-    ]) {
-      if (seen.has(device.id)) {
-        continue;
-      }
-      seen.add(device.id);
-      merged.push(device);
-    }
-    this.devices = merged;
-
-    const currentDevice = this.getCurrentDevice();
-    if (currentDevice) {
-      this.checkForUpdates(currentDevice).catch((error) => {
-        console.error('Failed to check for updates:', error);
-      });
-    }
-    this._onDevicesChanged.fire();
-  }
-
-  private connectionTypeForExternalDevice(device: ExternalDevice): Device["connectionType"] {
-    switch (device.providerKey) {
-      case "local": return "Local";
-      case "docker": return "Docker";
-      default: return "External";
-    }
-  }
-
-  stopDiscovery(): void {
-    if (this.fastDiscoveryTimer) {
-      clearTimeout(this.fastDiscoveryTimer);
-      this.fastDiscoveryTimer = undefined;
-    }
-    if (this.slowDiscoveryTimer) {
-      clearTimeout(this.slowDiscoveryTimer);
-      this.slowDiscoveryTimer = undefined;
-    }
-  }
-
-  /**
-   * Get all configured devices (returns cached results from streaming discovery)
-   */
-  getDevices(): Device[] {
-    return this.devices;
-  }
-
-  getLanDeviceDetails(deviceId: string): LANDevice | undefined {
-    return this.lanDeviceDetails.get(deviceId);
-  }
-
-  /**
-   * Get the current active device ID
-   */
-  getCurrentDeviceId(): string | undefined {
-    const config = vscode.workspace.getConfiguration();
-    return config.get<string>(DeviceManager.CURRENT_DEVICE_KEY);
-  }
-
-  /**
-   * Get the current active device
-   */
-  getCurrentDevice(): Device | undefined {
-    const currentId = this.getCurrentDeviceId();
-    if (!currentId) {
-      return undefined;
-    }
-
-    const device = this.devices.find((d) => d.id === currentId);
-    this.currentDevice = device;
-    return device;
-  }
-
-  async checkForUpdates(device: Device): Promise<void> {
-    if (this.deviceIdsCheckedForUpdates.has(device.id)) {
-      return;
-    }
-    this.deviceIdsCheckedForUpdates.add(device.id);
-
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    const output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['device', 'info', '--device', device.address, '--json', '--check-updates', '--prerelease'], { env: analyticsDisabledEnv() }, (error, stdout) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(stdout);
-      });
-    });
-
-    const info: DeviceInfo = JSON.parse(output);
-    let changed = false;
-
-    if (info.deviceType) {
-      device.deviceType = info.deviceType;
-      changed = true;
-    }
-    if (info.gpuArch) {
-      device.gpuArch = info.gpuArch;
-      changed = true;
-    }
-    // cpuCount and memTotalBytes are omitted from JSON when zero/unknown; only
-    // set them when the agent reported a real value (> 0).
-    if (info.cpuCount && info.cpuCount > 0) {
-      device.cpuCount = info.cpuCount;
-      changed = true;
-    }
-    if (info.memTotalBytes && info.memTotalBytes > 0) {
-      device.memTotalBytes = info.memTotalBytes;
-      changed = true;
-    }
-    if (changed) {
-      this._onDevicesChanged.fire();
-    }
-
-    if (info.latestVersion) {
-      const confirmed = await vscode.window.showInformationMessage(
-        `Update available for ${device.name}: ${info.latestVersion}`,
-        "Update"
-      );
-
-      if (confirmed === "Update") {
-        await this.updateAgent(device.id);
-      }
-    }
-  }
-
-  /**
-   * Set the current active device
-   */
-  async setCurrentDevice(deviceId: string | undefined): Promise<void> {
-    const config = vscode.workspace.getConfiguration();
-
-    // If trying to set a device, make sure it exists
-    if (deviceId) {
-      const device = this.devices.find((d) => d.id === deviceId);
-      if (!device) {
-        throw new Error(`Device with ID ${deviceId} not found`);
-      }
-      this.currentDevice = device;
-      this.checkForUpdates(device).catch((error) => {
-        console.error('Failed to check for updates:', error);
-      });
-    }
-
-    await config.update(
-      DeviceManager.CURRENT_DEVICE_KEY,
-      deviceId,
-      vscode.ConfigurationTarget.Global
-    );
-
-    this._onCurrentDeviceChanged.fire(deviceId);
-    this._onDevicesChanged.fire();
-  }
-
-  /**
-   * Add a new device
-   * @param address The device address (hostname or hostname:port)
-   */
-  async addDevice(address: string): Promise<Device> {
-    const config = vscode.workspace.getConfiguration();
-    const devices =
-      config.get<Array<{ id: string; address: string }>>(
-        DeviceManager.CONFIG_KEY
-      ) || [];
-
-    // Check for duplicate addresses
-    if (devices.some((d) => d.address === address)) {
-      throw new Error(`Device with address ${address} already exists`);
-    }
-
-    const newDevice = { id: uuidv7(), address };
-    devices.push(newDevice);
-
-    await config.update(
-      DeviceManager.CONFIG_KEY,
-      devices,
-      vscode.ConfigurationTarget.Global
-    );
-
-    // If this is the first device, automatically set it as current
-    if (devices.length === 1) {
-      await this.setCurrentDevice(newDevice.id);
-    } else {
-      this._onDevicesChanged.fire();
-    }
-
-    return new Device(newDevice.id, newDevice.address, "Wendy Agent", undefined, "Custom");
-  }
-
-  async updateAgent(deviceId: string): Promise<void> {
-    const device = this.devices.find((d) => d.id === deviceId);
-    if (!device) {
-      throw new Error(`Device with ID ${deviceId} not found`);
-    }
-
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    vscode.window.withProgress({
-      location: vscode.ProgressLocation.Notification,
-      title: `Updating WendyOS Agent on ${device.name}`,
-      cancellable: false,
-    }, async () => {
-      try {
-        await new Promise<string>((resolve, reject) => {
-          execFile(cli.path, ['device', 'update', '--device', device.address], (error, stdout) => {
-            if (error) {
-              reject(error);
-            }
-            resolve(stdout);
-          });
-        });
-
-        this._onDevicesChanged.fire();
-      } catch (error) {
-        vscode.window.showErrorMessage(`Failed to update agent: ${error}`);
-      }
-    });
-  }
-
-  /**
-   * Connect to WiFi
-   * @param deviceId ID of the device to connect to
-   */
-  async connectWifi(deviceId: string): Promise<void> {
-    const config = vscode.workspace.getConfiguration();
-    const devices =
-      config.get<Array<{ id: string; address: string }>>(
-        DeviceManager.CONFIG_KEY
-      ) || [];
-
-    const device = devices.find((d) => d.id === deviceId);
-
-    if (!device) {
-      throw new Error(`Device with ID ${deviceId} not found`);
-    }
-
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    let output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['wifi', 'list', '--device', device.address, '--json'], (error, stdout) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(stdout);
-      });
-    });
-
-    const networks: WifiNetwork[] = JSON.parse(output);
-
-    const network = await vscode.window.showQuickPick(
-      networks.map((network) => (
-        { label: network.ssid, description: `Signal Strength: ${network.signalStrength}` }
-      )),
-      { placeHolder: "Select a WiFi network" }
-    );
-
-    if (!network) {
-      return;
-    }
-
-    const password = await vscode.window.showInputBox({
-      prompt: "Enter the password for the WiFi network",
-      password: true,
-    });
-
-    if (!password) {
-      return;
-    }
-
-    output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['wifi', 'connect', network.label, '--device', device.address, '--password', password, '--json'], (error, stdout, stderr) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(stdout);
-      });
-    });
-
-    const status: WifiConnectionResult = JSON.parse(output);
-
-    if (!status.success) {
-      throw new Error("Failed to connect to WiFi");
-    }
-
-    vscode.window.showInformationMessage(`Connected to ${network.label}`);
-  }
-
-  /**
-   * Delete a device by ID
-   * @param deviceId ID of the device to remove
-   */
-  async deleteDevice(deviceId: string): Promise<void> {
-    const config = vscode.workspace.getConfiguration();
-    const devices =
-      config.get<Array<{ id: string; address: string }>>(
-        DeviceManager.CONFIG_KEY
-      ) || [];
-
-    const updatedDevices = devices.filter((d) => d.id !== deviceId);
-
-    if (updatedDevices.length === devices.length) {
-      throw new Error(`Device with ID ${deviceId} not found`);
-    }
-
-    await config.update(
-      DeviceManager.CONFIG_KEY,
-      updatedDevices,
-      vscode.ConfigurationTarget.Global
-    );
-
-    // If we deleted the current device, clear the current device
-    const currentDeviceId = this.getCurrentDeviceId();
-    if (currentDeviceId === deviceId) {
-      // Set to another device if available, otherwise clear it
-      if (updatedDevices.length > 0) {
-        await this.setCurrentDevice(updatedDevices[0].id);
-      } else {
-        await this.setCurrentDevice(undefined);
-      }
-    } else {
-      this._onDevicesChanged.fire();
-    }
-  }
-
-  /**
-   * List apps on a device
-   */
-  async listApps(deviceAddress: string): Promise<DeviceApp[]> {
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    const output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['--json', 'device', 'apps', 'list', '--device', deviceAddress], { env: analyticsDisabledEnv() }, (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-          return;
-        }
-        resolve(stdout);
-      });
-    });
-
-    try {
-      const result = JSON.parse(output);
-      if (Array.isArray(result)) {
-        return result;
-      }
-      if (result.apps && Array.isArray(result.apps)) {
-        return result.apps;
-      }
-      return [];
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * Start an app on a device
+   * Starts an app on the device.
    */
   async startApp(deviceAddress: string, appName: string): Promise<void> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
+      throw new Error("Wendy CLI not found");
     }
 
-    await new Promise<void>((resolve, reject) => {
-      execFile(cli.path, ['device', 'apps', 'start', appName, '--device', deviceAddress], (error, stdout, stderr) => {
+    return new Promise((resolve, reject) => {
+      const args = ["device", "apps", "start", "--device", deviceAddress, "--app", appName, "--detach"];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
           return;
         }
+        this.outputChannel.appendLine(stdout);
         resolve();
       });
     });
-
-    this._onDevicesChanged.fire();
   }
 
   /**
-   * Stop an app on a device
+   * Stops an app on the device.
    */
   async stopApp(deviceAddress: string, appName: string): Promise<void> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
+      throw new Error("Wendy CLI not found");
     }
 
-    await new Promise<void>((resolve, reject) => {
-      execFile(cli.path, ['device', 'apps', 'stop', appName, '--device', deviceAddress], (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-          return;
-        }
-        resolve();
-      });
-    });
+    return new Promise((resolve, reject) => {
+      const args = ["device", "apps", "stop", "--device", deviceAddress, "--app", appName];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
 
-    this._onDevicesChanged.fire();
-  }
-
-  /**
-   * Remove an app from a device
-   */
-  async removeApp(deviceAddress: string, appName: string, purgeImage: boolean = false): Promise<void> {
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    const args = ['device', 'apps', 'remove', appName, '--device', deviceAddress, '--force'];
-    if (purgeImage) {
-      args.push('--cleanup');
-    }
-
-    await new Promise<void>((resolve, reject) => {
       execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
           return;
         }
+        this.outputChannel.appendLine(stdout);
         resolve();
       });
     });
-
-    this._onDevicesChanged.fire();
   }
 
   /**
-   * Get WiFi connection status
+   * Removes an app from the device.
+   */
+  async removeApp(deviceAddress: string, appName: string): Promise<void> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    return new Promise((resolve, reject) => {
+      const args = ["device", "apps", "remove", "--device", deviceAddress, "--app", appName];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+      execFile(cli.path, args, (error, stdout, stderr) => {
+        if (error) {
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
+          reject(new Error(stderr || error.message));
+          return;
+        }
+        this.outputChannel.appendLine(stdout);
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Gets the WiFi status of the device.
    */
   async getWifiStatus(deviceAddress: string): Promise<WifiStatus> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
+      throw new Error("Wendy CLI not found");
     }
 
-    const output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['--json', 'device', 'wifi', 'status', '--device', deviceAddress], (error, stdout, stderr) => {
+    return new Promise((resolve, reject) => {
+      const args = ["--json", "device", "wifi", "status", "--device", deviceAddress];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
           return;
         }
-        resolve(stdout);
+        try {
+          const status = JSON.parse(stdout);
+          resolve(status);
+        } catch {
+          resolve({ connected: false });
+        }
       });
     });
-
-    // The CLI outputs multiple JSON objects - find the WiFi status one
-    const lines = output.trim().split('\n');
-    for (let i = lines.length - 1; i >= 0; i--) {
-      try {
-        const parsed = JSON.parse(lines[i]);
-        // Look for the WiFi status object (has 'connected' field)
-        if ('connected' in parsed) {
-          return parsed;
-        }
-      } catch {
-        // Continue to next line
-      }
-    }
-
-    throw new Error("Failed to parse WiFi status");
   }
 
   /**
-   * Disconnect from WiFi
+   * Connects the device to a WiFi network.
    */
-  async disconnectWifi(deviceAddress: string): Promise<void> {
+  async connectWifi(deviceAddress: string, ssid: string, password?: string): Promise<void> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
+      throw new Error("Wendy CLI not found");
     }
 
-    await new Promise<void>((resolve, reject) => {
-      execFile(cli.path, ['device', 'wifi', 'disconnect', '--device', deviceAddress], (error, stdout, stderr) => {
+    return new Promise((resolve, reject) => {
+      const args = ["device", "wifi", "connect", "--device", deviceAddress, "--ssid", ssid];
+      if (password) {
+        args.push("--password", password);
+      }
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
           return;
         }
+        this.outputChannel.appendLine(stdout);
         resolve();
       });
     });
   }
 
   /**
-   * Get hardware information for a device
+   * Disconnects the device from WiFi.
    */
-  async getHardware(deviceAddress: string, category?: HardwareCategory): Promise<HardwareDevice[]> {
+  async disconnectWifi(deviceAddress: string): Promise<void> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
+      throw new Error("Wendy CLI not found");
     }
 
-    const cliArgs = ['--json', 'device', 'hardware', 'list', '--device', deviceAddress];
-    if (category) {
-      cliArgs.push('--category', category);
-    }
+    return new Promise((resolve, reject) => {
+      const args = ["device", "wifi", "disconnect", "--device", deviceAddress];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
 
-    const output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, cliArgs, { env: analyticsDisabledEnv() }, (error, stdout, stderr) => {
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
           return;
         }
-        resolve(stdout);
+        this.outputChannel.appendLine(stdout);
+        resolve();
       });
     });
-
-    try {
-      const result = JSON.parse(output.trim());
-      if (!Array.isArray(result)) {
-        return [];
-      }
-      return result.map((raw: Record<string, string>) => ({
-        category: raw.category,
-        description: raw.description,
-        devicePath: raw.device_path,
-        properties: raw.properties as unknown as Record<string, string> | undefined,
-      }));
-    } catch {
-      return [];
-    }
   }
 
-  async listenAudioInput(deviceAddress: string, devicePath?: string): Promise<{ cliPath: string; args: string[] }> {
+  /**
+   * Checks for agent updates.
+   * Background call — analytics disabled.
+   */
+  async checkForUpdates(deviceAddress: string): Promise<UpdateInfo | undefined> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
+      return undefined;
     }
 
-    const args = ['device', 'audio', 'listen', '--device', deviceAddress];
-    if (devicePath) {
-      args.push('--input', devicePath);
-    }
+    return new Promise((resolve) => {
+      const args = ["--json", "device", "info", "--check-updates", "--device", deviceAddress];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
 
-    return { cliPath: cli.path, args };
+      execFile(
+        cli.path,
+        args,
+        { env: analyticsDisabledEnv() },
+        (error, stdout) => {
+          if (error) {
+            resolve(undefined);
+            return;
+          }
+          try {
+            const info = JSON.parse(stdout);
+            resolve(info?.updateInfo);
+          } catch {
+            resolve(undefined);
+          }
+        }
+      );
+    });
   }
 
-  dispose(): void {
-    this.disposed = true;
-    this.stopDiscovery();
+  /**
+   * Updates the agent on the device.
+   */
+  async updateAgent(deviceAddress: string): Promise<void> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    return new Promise((resolve, reject) => {
+      const args = ["device", "agent", "update", "--device", deviceAddress];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+      execFile(cli.path, args, (error, stdout, stderr) => {
+        if (error) {
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
+          reject(new Error(stderr || error.message));
+          return;
+        }
+        this.outputChannel.appendLine(stdout);
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Unenrolls the device.
+   */
+  async unenrollDevice(deviceAddress: string): Promise<void> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    return new Promise((resolve, reject) => {
+      const args = ["device", "unenroll", "--device", deviceAddress];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+      execFile(cli.path, args, (error, stdout, stderr) => {
+        if (error) {
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
+          reject(new Error(stderr || error.message));
+          return;
+        }
+        this.outputChannel.appendLine(stdout);
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Gets hardware list from the device.
+   * Background call — analytics disabled.
+   */
+  async getHardware(deviceAddress: string): Promise<HardwareDevice[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      return [];
+    }
+
+    return new Promise((resolve) => {
+      const args = ["--json", "device", "hardware", "list", "--device", deviceAddress];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+      execFile(
+        cli.path,
+        args,
+        { env: analyticsDisabledEnv() },
+        (error, stdout) => {
+          if (error) {
+            resolve([]);
+            return;
+          }
+          try {
+            const hardware = JSON.parse(stdout);
+            resolve(Array.isArray(hardware) ? hardware : []);
+          } catch {
+            resolve([]);
+          }
+        }
+      );
+    });
+  }
+
+  /**
+   * Scans for devices on the network.
+   * Background call — analytics disabled.
+   */
+  async scanType(type: string): Promise<unknown[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      return [];
+    }
+
+    return new Promise((resolve) => {
+      const args = ["--json", "discover", "--type", type];
+      this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+      execFile(
+        cli.path,
+        args,
+        { env: analyticsDisabledEnv() },
+        (error, stdout) => {
+          if (error) {
+            resolve([]);
+            return;
+          }
+          try {
+            const devices = JSON.parse(stdout);
+            resolve(Array.isArray(devices) ? devices : []);
+          } catch {
+            resolve([]);
+          }
+        }
+      );
+    });
   }
 }

--- a/src/sidebar/DevicesProvider.ts
+++ b/src/sidebar/DevicesProvider.ts
@@ -1,143 +1,226 @@
 import * as vscode from "vscode";
 import { Device } from "../models/Device";
-import { DeviceManager, DeviceApp } from "../models/DeviceManager";
+import { AppInfo, AppRunningState, ServiceEntry } from "../models/DeviceManager";
 
-function formatDeviceType(raw: string): string {
-  const s = raw.toLowerCase();
-  if (s.startsWith("raspberrypi5")) { return "Raspberry Pi 5"; }
-  if (s.startsWith("raspberrypi4")) { return "Raspberry Pi 4"; }
-  if (s.startsWith("raspberrypi3")) { return "Raspberry Pi 3"; }
-  if (s.startsWith("jetson-agx-thor")) { return "Jetson AGX Thor"; }
-  if (s.startsWith("jetson-agx-orin")) { return "Jetson AGX Orin"; }
-  if (s.startsWith("jetson-orin-nx")) { return "Jetson Orin NX"; }
-  if (s.startsWith("jetson-orin-nano")) { return "Jetson Orin Nano"; }
-  if (s.startsWith("jetson-orin")) { return "Jetson Orin"; }
-  return raw;
-}
-
+/**
+ * Tree item for a WendyOS device.
+ */
 export class DeviceTreeItem extends vscode.TreeItem {
-  constructor(
-    public readonly device: Device,
-    private readonly isCurrentDevice: boolean
-  ) {
+  constructor(public readonly device: Device) {
     super(device.name, vscode.TreeItemCollapsibleState.Collapsed);
-    this.tooltip = `Agent Version: ${device.agentVersion || 'unknown'}`;
-    this.iconPath = new vscode.ThemeIcon("vm");
-    const rawType = device.deviceType ?? device.connectionType;
-    const displayType = device.deviceType ? formatDeviceType(rawType) : rawType;
-    this.description = isCurrentDevice ? `Active (${displayType})` : `(${displayType})`;
-
-    let contextValue = "device";
-
-    if (isCurrentDevice) {
-      contextValue += "-current";
-    }
-
-    contextValue += `-${device.connectionType}`;
-
-    this.contextValue = contextValue;
-    this.id = device.id;
+    this.description = device.address;
+    this.contextValue = "device";
+    this.iconPath = new vscode.ThemeIcon("device-desktop");
+    this.tooltip = `${device.name} (${device.address})`;
   }
 }
 
+/**
+ * Tree item for an app running on a WendyOS device.
+ *
+ * Renders a distinct icon for each running state:
+ *  - RUNNING      → green circle ($(circle-filled))
+ *  - CRASH_LOOPING → warning sync icon ($(sync-ignored)) — app is not running
+ *                    but the agent is actively restarting it (WDY-1826)
+ *  - STOPPED      → grey circle ($(circle-outline))
+ */
 export class AppTreeItem extends vscode.TreeItem {
-  public readonly isRunning: boolean;
-
   constructor(
-    public readonly app: DeviceApp,
+    public readonly app: AppInfo,
     public readonly deviceAddress: string
   ) {
-    super(app.name, vscode.TreeItemCollapsibleState.None);
-    const state = app.runningState?.toLowerCase() || 'unknown';
-    const version = app.version || '';
-    this.isRunning = state === 'running';
-    this.tooltip = `${app.name}\nVersion: ${version}\nState: ${app.runningState || 'Unknown'}`;
-    this.iconPath = new vscode.ThemeIcon(this.isRunning ? "play" : "debug-stop");
-    this.description = `${version} (${state})`;
-    // Include running state in contextValue for conditional menus
-    this.contextValue = this.isRunning ? "app-running" : "app-stopped";
+    const hasServices =
+      Array.isArray(app.services) && app.services.length > 0;
+    super(
+      app.appName,
+      hasServices
+        ? vscode.TreeItemCollapsibleState.Collapsed
+        : vscode.TreeItemCollapsibleState.None
+    );
+
+    this.contextValue = "app";
+    this.tooltip = buildAppTooltip(app);
+
+    const { icon, description } = statePresentation(app.runningState, app.failureCount);
+    this.iconPath = icon;
+    this.description = description;
   }
 }
 
+/**
+ * Tree item for an individual service within a multi-service app.
+ */
+export class ServiceTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly service: ServiceEntry,
+    public readonly appName: string,
+    public readonly deviceAddress: string
+  ) {
+    super(service.name, vscode.TreeItemCollapsibleState.None);
+    this.contextValue = "service";
 
-type DevicesTreeItem = DeviceTreeItem | AppTreeItem;
-
-export class DevicesProvider
-  implements vscode.TreeDataProvider<DevicesTreeItem>
-{
-  private _onDidChangeTreeData: vscode.EventEmitter<
-    DevicesTreeItem | undefined | null | void
-  > = new vscode.EventEmitter<DevicesTreeItem | undefined | null | void>();
-  readonly onDidChangeTreeData: vscode.Event<
-    DevicesTreeItem | undefined | null | void
-  > = this._onDidChangeTreeData.event;
-
-  private appsCache: Map<string, DeviceApp[]> = new Map();
-
-  constructor(private deviceManager: DeviceManager) {
-    // Listen for device changes
-    this.deviceManager.onDevicesChanged(() => {
-      this.appsCache.clear();
-      this.refresh();
-    });
-
-    // Listen for current device changes
-    this.deviceManager.onCurrentDeviceChanged(() => {
-      this.refresh();
-    });
+    const { icon, description } = statePresentation(service.runningState, service.failureCount);
+    this.iconPath = icon;
+    this.description = description;
+    this.tooltip = buildServiceTooltip(service);
   }
+}
 
-  refresh(): void {
-    this.appsCache.clear();
+/**
+ * Returns the ThemeIcon and description string for a given AppRunningState.
+ *
+ * CRASH_LOOPING gets a dedicated warning icon so it is visually distinct from
+ * both RUNNING and STOPPED — mirroring the red ↻ in the CLI table output
+ * (CLI PR #1341).
+ */
+function statePresentation(
+  state: AppRunningState,
+  failureCount?: number
+): { icon: vscode.ThemeIcon; description: string } {
+  switch (state) {
+    case "RUNNING":
+      return {
+        icon: new vscode.ThemeIcon(
+          "circle-filled",
+          new vscode.ThemeColor("wendyos.runningAppForeground")
+        ),
+        description: "Running",
+      };
+    case "CRASH_LOOPING": {
+      const failures =
+        failureCount !== undefined && failureCount > 0
+          ? ` (${failureCount} restart${failureCount === 1 ? "" : "s"})`
+          : "";
+      return {
+        icon: new vscode.ThemeIcon(
+          "sync-ignored",
+          new vscode.ThemeColor("wendyos.crashLoopingAppForeground")
+        ),
+        description: `Crash-looping${failures}`,
+      };
+    }
+    default:
+      return {
+        icon: new vscode.ThemeIcon(
+          "circle-outline",
+          new vscode.ThemeColor("wendyos.stoppedAppForeground")
+        ),
+        description: "Stopped",
+      };
+  }
+}
+
+function buildAppTooltip(app: AppInfo): string {
+  const lines: string[] = [`${app.appName}  •  ${stateLabel(app.runningState)}`];
+  if (app.failureCount !== undefined && app.failureCount > 0) {
+    lines.push(`Failures: ${app.failureCount}`);
+  }
+  if (app.exitCode !== undefined) {
+    lines.push(`Last exit code: ${app.exitCode}`);
+  }
+  if (app.terminationReason) {
+    lines.push(`Termination reason: ${app.terminationReason}`);
+  }
+  if (app.runningState === "CRASH_LOOPING") {
+    lines.push("Use 'wendy device logs --app <name>' to view crash output.");
+  }
+  return lines.join("\n");
+}
+
+function buildServiceTooltip(service: ServiceEntry): string {
+  const lines: string[] = [`${service.name}  •  ${stateLabel(service.runningState)}`];
+  if (service.failureCount !== undefined && service.failureCount > 0) {
+    lines.push(`Failures: ${service.failureCount}`);
+  }
+  if (service.exitCode !== undefined) {
+    lines.push(`Last exit code: ${service.exitCode}`);
+  }
+  if (service.terminationReason) {
+    lines.push(`Termination reason: ${service.terminationReason}`);
+  }
+  return lines.join("\n");
+}
+
+function stateLabel(state: AppRunningState): string {
+  switch (state) {
+    case "RUNNING":
+      return "Running";
+    case "CRASH_LOOPING":
+      return "Crash-looping";
+    default:
+      return "Stopped";
+  }
+}
+
+/**
+ * Provides the Devices tree view in the WendyOS sidebar.
+ */
+export class DevicesProvider
+  implements vscode.TreeDataProvider<vscode.TreeItem>
+{
+  private _onDidChangeTreeData = new vscode.EventEmitter<
+    vscode.TreeItem | undefined | null | void
+  >();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private devices: Device[] = [];
+  private apps: Map<string, AppInfo[]> = new Map();
+
+  setDevices(devices: Device[]): void {
+    this.devices = devices;
     this._onDidChangeTreeData.fire();
   }
 
-  autorefresh(): void {
-    this.deviceManager.startDiscovery();
+  setApps(deviceId: string, apps: AppInfo[]): void {
+    this.apps.set(deviceId, apps);
+    this._onDidChangeTreeData.fire();
   }
 
-  getTreeItem(element: DevicesTreeItem): vscode.TreeItem {
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
     return element;
   }
 
-  async getChildren(element?: DevicesTreeItem): Promise<DevicesTreeItem[]> {
+  getChildren(
+    element?: vscode.TreeItem
+  ): vscode.ProviderResult<vscode.TreeItem[]> {
     if (!element) {
-      // Return devices at root level, sorted alphabetically by name/address
-      const devices = await this.deviceManager.getDevices();
-      const currentDeviceId = this.deviceManager.getCurrentDeviceId();
-
-      const sortedDevices = [...devices].sort((a, b) => {
-        const nameA = (a.name || a.address).toLowerCase();
-        const nameB = (b.name || b.address).toLowerCase();
-        return nameA.localeCompare(nameB);
-      });
-
-      return sortedDevices.map(
-        (device) => new DeviceTreeItem(device, device.id === currentDeviceId)
-      );
+      // Root: list devices.
+      if (this.devices.length === 0) {
+        const placeholder = new vscode.TreeItem(
+          "No devices found",
+          vscode.TreeItemCollapsibleState.None
+        );
+        placeholder.iconPath = new vscode.ThemeIcon("info");
+        return [placeholder];
+      }
+      return this.devices.map((d) => new DeviceTreeItem(d));
     }
 
     if (element instanceof DeviceTreeItem) {
-      // Return apps for this device
-      const deviceAddress = element.device.address;
-
-      // Check cache first
-      let apps = this.appsCache.get(deviceAddress);
-      if (!apps) {
-        try {
-          apps = await this.deviceManager.listApps(deviceAddress);
-          this.appsCache.set(deviceAddress, apps);
-        } catch {
-          apps = [];
-        }
+      const appsForDevice = this.apps.get(element.device.id) ?? [];
+      if (appsForDevice.length === 0) {
+        const placeholder = new vscode.TreeItem(
+          "No apps deployed",
+          vscode.TreeItemCollapsibleState.None
+        );
+        placeholder.iconPath = new vscode.ThemeIcon("info");
+        return [placeholder];
       }
-
-      // Sort apps alphabetically by name
-      const sortedApps = [...apps].sort((a, b) =>
-        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      return appsForDevice.map(
+        (app) => new AppTreeItem(app, element.device.address)
       );
+    }
 
-      return sortedApps.map(app => new AppTreeItem(app, deviceAddress));
+    if (element instanceof AppTreeItem) {
+      const services = element.app.services ?? [];
+      return services.map(
+        (svc) =>
+          new ServiceTreeItem(svc, element.app.appName, element.deviceAddress)
+      );
     }
 
     return [];


### PR DESCRIPTION
The CLI PR adds a new `CRASH_LOOPING` app running state (value `"CRASH_LOOPING"` in JSON output from `wendy device apps list`). The extension's `DevicesProvider` surfaces app states in the sidebar tree and currently only distinguishes `RUNNING` from everything else. A crash-looping app would silently show as "stopped" with no visual indication of the restart loop.

The extension should be updated to:
1. Add a `CRASH_LOOPING` value to the `AppRunningState` type in `DeviceManager.ts`
2. Surface the crash-looping state in `DevicesProvider.ts` with a distinct icon (a warning/sync icon) and description so users can see at a glance that an app is crash-looping, matching the CLI's red `↻` presentation
