### PR TITLE
feat(vscode): proposal for WendyOS#1247

### DIFF
--- a/schemas/wendy-schema.json
+++ b/schemas/wendy-schema.json
@@ -313,6 +313,22 @@
           "required": ["type"],
           "additionalProperties": false,
           "description": "HID input device access (barcode scanners, keyboards, etc.)."
+        },
+        {
+          "properties": {
+            "type": { "const": "admin" }
+          },
+          "required": ["type"],
+          "additionalProperties": false,
+          "description": "Full local device control over the agent's unauthenticated Unix socket. Grants the ability to start/stop/delete any app, read all telemetry, exec into any container, and trigger OS/agent updates. Deploy only to trusted, first-party devices."
+        },
+        {
+          "properties": {
+            "type": { "const": "build" }
+          },
+          "required": ["type"],
+          "additionalProperties": false,
+          "description": "On-device container image builder (BuildKit). Grants CAP_SYS_ADMIN and the namespace syscalls required for a nested runc executor — privileged-equivalent. Stacks on the admin entitlement for the claude-on-device use case. Deploy only to trusted, first-party devices."
         }
       ]
     },

--- a/src/models/ProjectManager.ts
+++ b/src/models/ProjectManager.ts
@@ -3,7 +3,21 @@ import * as path from "path";
 import { execFile } from "child_process";
 import { WendyCLI } from "../wendy-cli/wendy-cli";
 
-export type EntitlementType = 'network' | 'video' | 'audio' | 'bluetooth' | 'gpu' | 'persist';
+export type EntitlementType =
+  | "network"
+  | "video"
+  | "audio"
+  | "bluetooth"
+  | "gpu"
+  | "persist"
+  | "camera"
+  | "usb"
+  | "i2c"
+  | "gpio"
+  | "spi"
+  | "input"
+  | "admin"
+  | "build";
 
 export interface Entitlement {
   type: EntitlementType;


### PR DESCRIPTION
The CLI diff introduces two new entitlement types in `wendy.json`:

1. **`admin`** — existed previously but was not represented in the extension's JSON schema or `EntitlementType` union (it was implicitly present in `oci/entitlements.go` but never surfaced in the schema).
2. **`build`** — brand new entitlement (`applyBuild`) that grants privileged-equivalent capabilities for on-device BuildKit. The example `Examples/ClaudeOnDevice/wendy.json` already uses `{"type":"build"}`.

Both entitlement types need to be added to:
- `schemas/wendy-schema.json` — the `oneOf` array in the `entitlement` `$def`. Without this, any `wendy.json` that declares `admin` or `build` will show a JSON schema validation error (red squiggle) in the editor, since the schema uses `oneOf` with `additionalProperties: false` on each variant.
- `src/models/ProjectManager.ts` — the `EntitlementType` union, so the extension can programmatically represent and manipulate these entitlements.

No other extension changes are warranted: `wendy device attach` is a new interactive PTY command, but the extension surfaces interactive device commands via `vscode.window.createTerminal`, not by enumerating subcommands; there is no existing attach-command wrapper to update.
