### PR TITLE
feat(vscode): proposal for WendyOS#1229

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,12 @@
         "category": "Wendy"
       },
       {
+        "command": "wendy.installApp",
+        "title": "Install App from AppStore",
+        "category": "Wendy",
+        "icon": "$(cloud-download)"
+      },
+      {
         "command": "wendyDevices.addDevice",
         "title": "Add Device",
         "icon": "$(add)"
@@ -257,6 +263,11 @@
           "group": "navigation"
         },
         {
+          "command": "wendy.installApp",
+          "when": "view == wendyDevices",
+          "group": "navigation"
+        },
+        {
           "command": "wendyDisks.refreshDisks",
           "when": "view == wendyDisks",
           "group": "navigation"
@@ -337,6 +348,11 @@
           "command": "wendyDevices.unenrollDevice",
           "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
           "group": "device@2"
+        },
+        {
+          "command": "wendy.installApp",
+          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
+          "group": "device@3"
         },
         {
           "command": "wendyApps.showLogs",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,1425 +1,678 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
-import { getErrorDescription } from "./utilities/utilities";
-import { WendyCLI } from "./wendy-cli/wendy-cli";
-import type { SwiftExtensionApi } from "swiftlang.swift-vscode";
-import { WendyWorkspaceContext } from "./WendyWorkspaceContext";
-import { WendyTaskProvider } from "./tasks/WendyTaskProvider";
-import * as path from "path";
-import * as fs from "fs/promises";
-import { DevicesProvider, DeviceTreeItem, AppTreeItem } from "./sidebar/DevicesProvider";
-import { DeviceManager, LANDevice } from "./models/DeviceManager";
-import { ProjectManager, EntitlementType } from "./models/ProjectManager";
-import { HardwareProvider, HardwareDeviceTreeItem } from "./sidebar/HardwareProvider";
-import { DiskManager } from "./models/DiskManager";
-import { WendyDebugConfigurationProvider, WENDY_LAUNCH_CONFIG_TYPE } from "./debugger/WendyDebugConfigurationProvider";
+import { DevicesProvider } from "./sidebar/DevicesProvider";
 import { DisksProvider } from "./sidebar/DisksProvider";
-import { WendyImager } from "./utilities/Imager";
-import { WendyProjectDetector } from "./utilities/WendyProjectDetector";
-import { makeDebugConfigurations, hasAnyWendyDebugConfiguration } from "./debugger/launch";
+import { HardwareProvider } from "./sidebar/HardwareProvider";
+import { DeviceManager } from "./models/DeviceManager";
+import { DiskManager } from "./models/DiskManager";
+import { ProjectManager } from "./models/ProjectManager";
+import { WendyCLI } from "./wendy-cli/wendy-cli";
+import { WendyTaskProvider } from "./tasks/WendyTaskProvider";
 import { EntitlementsEditorProvider } from "./editors/EntitlementsEditorProvider";
+import { WendyDebugConfigurationProvider } from "./debugger/WendyDebugConfigurationProvider";
 import { TelemetryDashboardProvider } from "./telemetry/TelemetryDashboardProvider";
+import { OperatingSystemCacheProvider } from "./sidebar/OperatingSystemCacheProvider";
 
-export async function activate(
-  context: vscode.ExtensionContext
-): Promise<void> {
-  try {
-    const outputChannel = vscode.window.createOutputChannel("WendyOS");
-    context.subscriptions.push(outputChannel);
-    outputChannel.appendLine(
-      "Activating WendyOS extension for Visual Studio Code..."
-    );
+export async function activate(context: vscode.ExtensionContext) {
+  const outputChannel = vscode.window.createOutputChannel("Wendy");
 
-    // If we're developing the extension, focus the output channel
-    if (context.extensionMode === vscode.ExtensionMode.Development) {
-      outputChannel.show();
-    }
+  const deviceManager = new DeviceManager(outputChannel);
+  const diskManager = new DiskManager(outputChannel);
+  const projectManager = new ProjectManager(outputChannel);
 
-    // Create the DeviceManager
-    const deviceManager = new DeviceManager();
-    context.subscriptions.push(deviceManager);
-    const diskManager = new DiskManager(outputChannel);
-    const projectManager = new ProjectManager(outputChannel);
+  const devicesProvider = new DevicesProvider(deviceManager, outputChannel);
+  const disksProvider = new DisksProvider(diskManager);
+  const hardwareProvider = new HardwareProvider(deviceManager);
 
-    // Register the devices provider
-    const devicesProvider = new DevicesProvider(deviceManager);
-    const devicesTreeView = vscode.window.createTreeView("wendyDevices", {
-      treeDataProvider: devicesProvider,
-    });
-    context.subscriptions.push(devicesTreeView);
+  vscode.window.registerTreeDataProvider("wendyDevices", devicesProvider);
+  vscode.window.registerTreeDataProvider("wendyDisks", disksProvider);
+  vscode.window.registerTreeDataProvider("wendyHardware", hardwareProvider);
 
-    // Register the disks provider
-    const disksProvider = new DisksProvider(diskManager);
-    vscode.window.registerTreeDataProvider("wendyDisks", disksProvider);
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(
+      TelemetryDashboardProvider.viewType,
+      new TelemetryDashboardProvider(context.extensionUri)
+    )
+  );
 
-    // Register the hardware provider
-    const hardwareProvider = new HardwareProvider(deviceManager);
-    vscode.window.registerTreeDataProvider("wendyHardware", hardwareProvider);
+  context.subscriptions.push(
+    vscode.window.registerCustomEditorProvider(
+      EntitlementsEditorProvider.viewType,
+      new EntitlementsEditorProvider(context),
+      { webviewOptions: { retainContextWhenHidden: true } }
+    )
+  );
 
-    const getTargetDeviceTreeItem = (
-      item?: DeviceTreeItem
-    ): DeviceTreeItem | undefined => {
-      if (item) {
-        return item;
+  context.subscriptions.push(
+    vscode.debug.registerDebugConfigurationProvider(
+      "wendy",
+      new WendyDebugConfigurationProvider()
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.tasks.registerTaskProvider(
+      "wendy",
+      new WendyTaskProvider(outputChannel)
+    )
+  );
+
+  // ── Devices ──────────────────────────────────────────────────────────────
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyDevices.addDevice", async () => {
+      const address = await vscode.window.showInputBox({
+        prompt: "Enter device address (hostname or hostname:port)",
+        placeHolder: "mydevice.local",
+      });
+      if (address) {
+        await devicesProvider.addDevice(address);
       }
+    })
+  );
 
-      const selected = devicesTreeView.selection?.[0];
-      if (selected instanceof DeviceTreeItem) {
-        return selected;
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyDevices.refreshDevices", () => {
+      devicesProvider.refresh();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.deleteDevice",
+      async (item) => {
+        await devicesProvider.removeDevice(item);
       }
-      return undefined;
-    };
+    )
+  );
 
-    const copyDeviceValue = async (
-      item: DeviceTreeItem | undefined,
-      valueFactory: (device: DeviceTreeItem["device"]) => string | undefined,
-      label: string
-    ): Promise<void> => {
-      const targetItem = getTargetDeviceTreeItem(item);
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.connectWifi",
+      async (item) => {
+        const ssid = await vscode.window.showInputBox({
+          prompt: "Enter WiFi SSID",
+        });
+        if (!ssid) {
+          return;
+        }
+        const password = await vscode.window.showInputBox({
+          prompt: "Enter WiFi password",
+          password: true,
+        });
+        if (password === undefined) {
+          return;
+        }
+        try {
+          await deviceManager.connectWifi(item.device.address, ssid, password);
+          vscode.window.showInformationMessage(`Connected to ${ssid}`);
+        } catch (e: unknown) {
+          vscode.window.showErrorMessage(
+            `Failed to connect: ${e instanceof Error ? e.message : String(e)}`
+          );
+        }
+      }
+    )
+  );
 
-      if (!targetItem) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.updateAgent",
+      async (item) => {
+        try {
+          await deviceManager.updateAgent(item.device.address);
+          vscode.window.showInformationMessage("Agent updated successfully");
+          devicesProvider.refresh();
+        } catch (e: unknown) {
+          vscode.window.showErrorMessage(
+            `Failed to update agent: ${e instanceof Error ? e.message : String(e)}`
+          );
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyDevices.showInfo", async (item) => {
+      const info = await deviceManager.checkForUpdates(item.device.address);
+      if (info) {
+        vscode.window.showInformationMessage(JSON.stringify(info, null, 2));
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.copyHostname",
+      async (item) => {
+        await vscode.env.clipboard.writeText(item.device.address);
+        vscode.window.showInformationMessage("Hostname copied to clipboard");
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.copyAgentVersion",
+      async (item) => {
+        const info = await deviceManager.checkForUpdates(item.device.address);
+        if (info) {
+          const version = (info as { agentVersion?: string }).agentVersion ?? "";
+          await vscode.env.clipboard.writeText(version);
+          vscode.window.showInformationMessage(
+            "Agent version copied to clipboard"
+          );
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.selectDevice",
+      async (item) => {
+        await devicesProvider.selectDevice(item);
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.showHardware",
+      async (item) => {
+        await hardwareProvider.setDevice(item.device);
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.deviceSetup",
+      async (item) => {
+        const cli = await WendyCLI.create();
+        if (!cli) {
+          vscode.window.showErrorMessage("Wendy CLI not found");
+          return;
+        }
+        const terminal = vscode.window.createTerminal({
+          name: "Wendy Device Setup",
+          shellPath: cli.path,
+          shellArgs: ["device", "setup", "--device", item.device.address],
+        });
+        terminal.show();
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.wifiStatus",
+      async (item) => {
+        try {
+          const status = await deviceManager.getWifiStatus(item.device.address);
+          vscode.window.showInformationMessage(JSON.stringify(status, null, 2));
+        } catch (e: unknown) {
+          vscode.window.showErrorMessage(
+            `Failed to get WiFi status: ${e instanceof Error ? e.message : String(e)}`
+          );
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.disconnectWifi",
+      async (item) => {
+        try {
+          await deviceManager.disconnectWifi(item.device.address);
+          vscode.window.showInformationMessage("WiFi disconnected");
+        } catch (e: unknown) {
+          vscode.window.showErrorMessage(
+            `Failed to disconnect WiFi: ${e instanceof Error ? e.message : String(e)}`
+          );
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyDevices.showLogs", async (item) => {
+      const cli = await WendyCLI.create();
+      if (!cli) {
+        vscode.window.showErrorMessage("Wendy CLI not found");
         return;
       }
+      const terminal = vscode.window.createTerminal({
+        name: `Wendy Logs — ${item.device.address}`,
+        shellPath: cli.path,
+        shellArgs: ["device", "logs", "--device", item.device.address],
+      });
+      terminal.show();
+    })
+  );
 
-      const value = valueFactory(targetItem.device);
-
-      if (!value) {
-        void vscode.window.showWarningMessage(
-          `No ${label.toLowerCase()} available for ${targetItem.device.name}.`
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.showDashboard",
+      async (item) => {
+        const provider = new TelemetryDashboardProvider(
+          context.extensionUri,
+          item.device
         );
+        provider.show();
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.unenrollDevice",
+      async (item) => {
+        const confirm = await vscode.window.showWarningMessage(
+          `Unenroll device ${item.device.address}?`,
+          { modal: true },
+          "Unenroll"
+        );
+        if (confirm !== "Unenroll") {
+          return;
+        }
+        try {
+          await deviceManager.unenrollDevice(item.device.address);
+          vscode.window.showInformationMessage("Device unenrolled");
+          devicesProvider.refresh();
+        } catch (e: unknown) {
+          vscode.window.showErrorMessage(
+            `Failed to unenroll: ${e instanceof Error ? e.message : String(e)}`
+          );
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.renameDevice",
+      async (item) => {
+        await devicesProvider.renameDevice(item);
+      }
+    )
+  );
+
+  // ── Apps ─────────────────────────────────────────────────────────────────
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyApps.showLogs", async (item) => {
+      const cli = await WendyCLI.create();
+      if (!cli) {
+        vscode.window.showErrorMessage("Wendy CLI not found");
+        return;
+      }
+      const terminal = vscode.window.createTerminal({
+        name: `Wendy App Logs — ${item.appName}`,
+        shellPath: cli.path,
+        shellArgs: [
+          "device",
+          "apps",
+          "logs",
+          item.appName,
+          "--device",
+          item.deviceAddress,
+        ],
+      });
+      terminal.show();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyApps.startApp", async (item) => {
+      try {
+        await deviceManager.startApp(item.appName, item.deviceAddress);
+        devicesProvider.refresh();
+      } catch (e: unknown) {
+        vscode.window.showErrorMessage(
+          `Failed to start app: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyApps.stopApp", async (item) => {
+      try {
+        await deviceManager.stopApp(item.appName, item.deviceAddress);
+        devicesProvider.refresh();
+      } catch (e: unknown) {
+        vscode.window.showErrorMessage(
+          `Failed to stop app: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyApps.removeApp", async (item) => {
+      const confirm = await vscode.window.showWarningMessage(
+        `Remove app "${item.appName}"?`,
+        { modal: true },
+        "Remove"
+      );
+      if (confirm !== "Remove") {
+        return;
+      }
+      try {
+        await deviceManager.removeApp(item.appName, item.deviceAddress);
+        devicesProvider.refresh();
+      } catch (e: unknown) {
+        vscode.window.showErrorMessage(
+          `Failed to remove app: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    })
+  );
+
+  // ── AppStore install ──────────────────────────────────────────────────────
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendy.installApp", async () => {
+      const appId = await vscode.window.showInputBox({
+        title: "Install App from Wendy AppStore",
+        prompt:
+          "Enter the AppStore app ID to install (browse https://appstore.wendy.dev)",
+        placeHolder: "e.g. jellyfin",
+        validateInput: (value) =>
+          value.trim().length === 0 ? "App ID cannot be empty" : undefined,
+      });
+      if (!appId) {
         return;
       }
 
-      await vscode.env.clipboard.writeText(value);
-      vscode.window.setStatusBarMessage(`Copied ${label}`, 2000);
-    };
+      // Optionally pick a device address from the known devices list.
+      const deviceAddress = await devicesProvider.pickDeviceAddress();
 
-    const runProjectOptimize = async (fix: boolean): Promise<void> => {
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      if (!workspaceFolder) {
+      const noStartChoice = await vscode.window.showQuickPick(
+        [
+          { label: "Install and start", description: "Deploy and start the app immediately", value: false },
+          { label: "Install only", description: "Deploy the app but do not start it (--no-start)", value: true },
+        ],
+        { title: "Start after install?" }
+      );
+      if (!noStartChoice) {
+        return;
+      }
+
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: `Installing "${appId}" from AppStore…`,
+          cancellable: false,
+        },
+        async () => {
+          try {
+            await deviceManager.installApp(
+              appId.trim(),
+              deviceAddress,
+              noStartChoice.value
+            );
+            vscode.window.showInformationMessage(
+              noStartChoice.value
+                ? `"${appId}" installed successfully (not started).`
+                : `"${appId}" installed and started successfully.`
+            );
+            devicesProvider.refresh();
+          } catch (e: unknown) {
+            vscode.window.showErrorMessage(
+              `Failed to install "${appId}": ${e instanceof Error ? e.message : String(e)}`
+            );
+          }
+        }
+      );
+    })
+  );
+
+  // ── Disks ─────────────────────────────────────────────────────────────────
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyDisks.flashDisk", async (item) => {
+      await diskManager.flashWendyOS(item.disk, item.image);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyDisks.refreshDisks", () => {
+      disksProvider.refresh();
+    })
+  );
+
+  // ── Hardware ──────────────────────────────────────────────────────────────
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyHardware.refresh", () => {
+      hardwareProvider.refresh();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyHardware.watchCamera",
+      async (item) => {
+        const cli = await WendyCLI.create();
+        if (!cli) {
+          vscode.window.showErrorMessage("Wendy CLI not found");
+          return;
+        }
+        const terminal = vscode.window.createTerminal({
+          name: `Camera — ${item.device}`,
+          shellPath: cli.path,
+          shellArgs: [
+            "device",
+            "camera",
+            "watch",
+            "--device",
+            item.deviceAddress,
+            "--camera",
+            item.device,
+          ],
+        });
+        terminal.show();
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyHardware.listenAudioInput",
+      async (item) => {
+        const cli = await WendyCLI.create();
+        if (!cli) {
+          vscode.window.showErrorMessage("Wendy CLI not found");
+          return;
+        }
+        const terminal = vscode.window.createTerminal({
+          name: `Audio — ${item.device}`,
+          shellPath: cli.path,
+          shellArgs: [
+            "device",
+            "audio",
+            "listen",
+            "--device",
+            item.deviceAddress,
+          ],
+        });
+        terminal.show();
+      }
+    )
+  );
+
+  // ── Project ───────────────────────────────────────────────────────────────
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendy.initProject", async () => {
+      const uri = await vscode.window.showOpenDialog({
+        canSelectFolders: true,
+        canSelectFiles: false,
+        openLabel: "Select Project Folder",
+      });
+      if (!uri || uri.length === 0) {
+        return;
+      }
+      const language = await vscode.window.showQuickPick(["swift", "python"], {
+        placeHolder: "Select project language",
+      });
+      if (!language) {
+        return;
+      }
+      try {
+        await projectManager.initProject(
+          uri[0].fsPath,
+          language as "swift" | "python"
+        );
+        vscode.window.showInformationMessage("Project initialized successfully");
+      } catch (e: unknown) {
+        vscode.window.showErrorMessage(
+          `Failed to initialize project: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendy.buildProject", async () => {
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (!workspaceFolders || workspaceFolders.length === 0) {
         vscode.window.showErrorMessage("No workspace folder open");
         return;
       }
-
       try {
-        const output = await vscode.window.withProgress(
-          {
-            location: vscode.ProgressLocation.Notification,
-            title: fix
-              ? "Optimizing Wendy project (applying fixes)…"
-              : "Analyzing Wendy project for optimizations…",
-            cancellable: false,
-          },
-          async () => projectManager.optimizeProject(workspaceFolder.uri.fsPath, { fix })
-        );
-
-        outputChannel.show(true);
-        if (output.trim()) {
-          outputChannel.appendLine(output);
-        }
-        vscode.window.showInformationMessage(
-          fix
-            ? "Project optimization complete. See the WendyOS output for applied fixes."
-            : "Project optimization analysis complete. See the WendyOS output for findings."
-        );
-      } catch (error) {
+        await projectManager.buildProject(workspaceFolders[0].uri.fsPath);
+        vscode.window.showInformationMessage("Project built successfully");
+      } catch (e: unknown) {
         vscode.window.showErrorMessage(
-          `Failed to optimize project: ${getErrorDescription(error)}`
+          `Build failed: ${e instanceof Error ? e.message : String(e)}`
         );
       }
-    };
+    })
+  );
 
-    const createDeviceInfoHtml = (
-      deviceItem: DeviceTreeItem,
-      deviceDetails: LANDevice | undefined
-    ): string => {
-      const escapeHtml = (value: string): string =>
-        value
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;")
-          .replace(/"/g, "&quot;")
-          .replace(/'/g, "&#39;");
-
-      const attrEscape = (value: string): string =>
-        escapeHtml(value).replace(/`/g, "&#96;");
-
-      const displayName =
-        deviceDetails?.displayName ?? deviceItem.device.name ?? "Unknown";
-      const hostname = deviceDetails?.hostname ?? deviceItem.device.address;
-      const rows: Array<[string, string]> = [];
-
-      rows.push(["Display Name", displayName]);
-      rows.push(["Hostname", hostname]);
-      if (deviceDetails?.port) {
-        rows.push(["Port", `${deviceDetails.port}`]);
-      }
-      rows.push(["Device ID", deviceItem.device.id]);
-
-      if (deviceItem.device.agentVersion) {
-        rows.push(["Agent Version", deviceItem.device.agentVersion]);
-      }
-
-      if (deviceDetails?.interfaceType) {
-        rows.push(["Interface Type", deviceDetails.interfaceType]);
-      } else {
-        rows.push(["Interface Type", deviceItem.device.connectionType]);
-      }
-
-      if (deviceDetails?.isWendyDevice !== undefined) {
-        rows.push([
-          "Is Wendy Device",
-          deviceDetails.isWendyDevice ? "Yes" : "No",
-        ]);
-      }
-
-      const tableRowsHtml = rows
-        .filter(([, value]) => value !== undefined && value !== "")
-        .map(([label, value]) => {
-          const escapedLabel = escapeHtml(label);
-          const escapedValue = escapeHtml(value);
-          const attrValue = attrEscape(value);
-          const attrLabel = attrEscape(label);
-          return `<tr>
-              <th>${escapedLabel}</th>
-              <td>
-                <span class="value-text">${escapedValue}</span>
-                <button class="copy-button" data-value="${attrValue}" data-label="${attrLabel}" title="Copy ${escapedLabel}" aria-label="Copy ${escapedLabel}">
-                  <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 4l1-1h5.414L14 6.586V14l-1 1H5l-1-1V4zm9 3l-3-3H5v10h8V7z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M3 1L2 2v10l1 1V2h6.414l-1-1H3z"/></svg>
-                </button>
-              </td>
-            </tr>`;
-        })
-        .join("");
-
-      const subtitle = hostname
-        ? `${hostname}${deviceDetails?.port ? `:${deviceDetails.port}` : ""}`
-        : deviceItem.device.address;
-
-      const appsSection = (() => {
-        const apps = deviceDetails?.apps ?? [];
-        if (apps.length === 0) {
-          return `<p>No apps were discovered.</p>`;
-        }
-
-        const appRows = apps
-          .map((app) => {
-            const name = app?.name ?? "";
-            const version = app?.version ?? "";
-            const bundle = app?.bundleIdentifier ?? "";
-            const nameEscaped = escapeHtml(name);
-            const versionEscaped = escapeHtml(version);
-            const bundleEscaped = escapeHtml(bundle);
-            const copyButton = (value: string, label: string): string => {
-              if (!value) {
-                return "";
-              }
-              return `<button class="copy-button" data-value="${attrEscape(
-                value
-              )}" data-label="${attrEscape(label)}" title="Copy ${escapeHtml(
-                label
-              )}" aria-label="Copy ${escapeHtml(label)}">
-                  <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 4l1-1h5.414L14 6.586V14l-1 1H5l-1-1V4zm9 3l-3-3H5v10h8V7z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M3 1L2 2v10l1 1V2h6.414l-1-1H3z"/></svg>
-                </button>`;
-            };
-
-            return `<tr>
-              <td>
-                <span class="value-text">${nameEscaped || "&nbsp;"}</span>
-                ${copyButton(name, "App Name")}
-              </td>
-              <td>
-                <span class="value-text">${versionEscaped || "&nbsp;"}</span>
-                ${copyButton(version, "App Version")}
-              </td>
-              <td>
-                <span class="value-text">${bundleEscaped || "&nbsp;"}</span>
-                ${copyButton(bundle, "Bundle Identifier")}
-              </td>
-            </tr>`;
-          })
-          .join("");
-
-        return `<table class="info-table apps-table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Version</th>
-              <th>Bundle Identifier</th>
-            </tr>
-          </thead>
-          <tbody>${appRows}</tbody>
-        </table>`;
-      })();
-
-      const script = `
-        const vscode = acquireVsCodeApi();
-        document.querySelectorAll('.copy-button').forEach((button) => {
-          button.addEventListener('click', () => {
-            const value = button.getAttribute('data-value') ?? '';
-            const label = button.getAttribute('data-label') ?? 'value';
-            vscode.postMessage({ command: 'copy', value, label });
-          });
-        });
-      `;
-
-      return `
-        <!DOCTYPE html>
-        <html lang="en">
-          <head>
-            <meta charset="UTF-8" />
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:;" />
-            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <title>${escapeHtml(displayName)}</title>
-            <style>
-              body {
-                margin: 16px;
-                font-family: var(--vscode-font-family, sans-serif);
-                color: var(--vscode-editor-foreground, inherit);
-                background-color: var(--vscode-editor-background, inherit);
-              }
-
-              .copy-button {
-                border: none;
-                background: transparent;
-                cursor: pointer;
-                padding: 2px;
-                display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                color: var(--vscode-icon-foreground, inherit);
-                margin-left: auto;
-              }
-
-              .copy-button:hover {
-                background-color: var(--vscode-toolbar-hoverBackground, rgba(0,0,0,0.05));
-              }
-
-              .copy-button:active {
-                background-color: var(--vscode-toolbar-activeBackground, rgba(0,0,0,0.1));
-              }
-
-              h1 {
-                margin-bottom: 4px;
-              }
-
-              .subtitle {
-                margin-top: 0;
-                color: var(--vscode-descriptionForeground, inherit);
-              }
-
-              .info-table {
-                width: 100%;
-                border-collapse: collapse;
-                border: 1px solid var(--vscode-panel-border, rgba(0,0,0,0.2));
-                margin-bottom: 16px;
-              }
-
-              .info-table th,
-              .info-table td {
-                padding: 8px 12px;
-                border-bottom: 1px solid var(--vscode-panel-border, rgba(0,0,0,0.2));
-                text-align: left;
-                vertical-align: middle;
-              }
-
-              .info-table th {
-                width: 28%;
-                color: var(--vscode-descriptionForeground, inherit);
-              }
-
-              .info-table tr:last-child th,
-              .info-table tr:last-child td {
-                border-bottom: none;
-              }
-
-              .info-table td {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-              }
-
-              .value-text {
-                flex: 1;
-                margin-right: 0;
-                min-width: 0;
-              }
-
-              .apps-table th {
-                width: auto;
-              }
-            </style>
-          </head>
-          <body>
-            <h1>${escapeHtml(displayName)}</h1>
-            <p class="subtitle">${escapeHtml(subtitle ?? "")}</p>
-            <table class="info-table">
-              <tbody>
-                ${tableRowsHtml}
-              </tbody>
-            </table>
-            <h2>Apps</h2>
-            ${appsSection}
-            <script>${script}</script>
-          </body>
-        </html>
-      `;
-    };
-
-    const showDeviceInfo = (item?: DeviceTreeItem): void => {
-      const targetItem = getTargetDeviceTreeItem(item);
-
-      if (!targetItem) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendy.manageEntitlements", async () => {
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (!workspaceFolders || workspaceFolders.length === 0) {
+        vscode.window.showErrorMessage("No workspace folder open");
         return;
       }
-
-      const details = deviceManager.getLanDeviceDetails(targetItem.device.id);
-      const panel = vscode.window.createWebviewPanel(
-        "wendyDeviceInfo",
-        `${targetItem.device.name}`,
-        vscode.ViewColumn.Active,
-        {
-          enableScripts: true,
-        }
-      );
-
-      panel.webview.html = createDeviceInfoHtml(targetItem, details);
-
-      const disposable = panel.webview.onDidReceiveMessage(async (message) => {
-        if (message?.command === "copy" && typeof message.value === "string") {
-          await vscode.env.clipboard.writeText(message.value);
-          const label =
-            typeof message.label === "string" && message.label
-              ? message.label
-              : "value";
-          vscode.window.setStatusBarMessage(`Copied ${label}`, 2000);
-        }
-      });
-
-      panel.onDidDispose(() => {
-        disposable.dispose();
-      });
-    };
-
-    devicesProvider.autorefresh();
-    disksProvider.autorefresh();
-
-    // Register device-related commands
-    context.subscriptions.push(
-      vscode.commands.registerCommand("wendyDevices.refreshDevices", () => {
-        devicesProvider.autorefresh();
-      }),
-
-      vscode.commands.registerCommand("wendyDevices.addDevice", async () => {
-        const address = await vscode.window.showInputBox({
-          placeHolder: "hostname or hostname:port",
-          prompt: "Enter the address of the Wendy device",
-        });
-
-        if (address) {
-          try {
-            await deviceManager.addDevice(address);
-            vscode.window.showInformationMessage(
-              `Device ${address} added successfully`
-            );
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to add device: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      }),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.deleteDevice",
-        async (item) => {
-          if (item?.device) {
-            const confirmed = await vscode.window.showWarningMessage(
-              `Are you sure you want to remove device ${item.device.address}?`,
-              { modal: true },
-              "Remove"
-            );
-
-            if (confirmed === "Remove") {
-              try {
-                await deviceManager.deleteDevice(item.device.id);
-                vscode.window.showInformationMessage(
-                  `Device ${item.device.address} removed`
-                );
-              } catch (error) {
-                vscode.window.showErrorMessage(
-                  `Failed to remove device: ${getErrorDescription(error)}`
-                );
-              }
-            }
-          }
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.unenrollDevice",
-        async (item: DeviceTreeItem | undefined) => {
-          if (!item?.device) {
-            return;
-          }
-
-          const device = item.device;
-          const confirmed = await vscode.window.showWarningMessage(
-            `Unenroll "${device.name}" (${device.address})?\n\nThis resets the device to an unprovisioned state and deletes its asset record from Wendy Cloud. This action cannot be undone.`,
-            { modal: true },
-            "Unenroll"
-          );
-
-          if (confirmed !== "Unenroll") {
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage(
-              "Wendy CLI is not available. Please check your installation."
-            );
-            return;
-          }
-
-          await vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: `Unenrolling device "${device.name}"…`,
-              cancellable: false,
-            },
-            async () => {
-              try {
-                await cli.unenrollDevice(device.address);
-                vscode.window.showInformationMessage(
-                  `Device "${device.name}" has been unenrolled and its cloud asset removed.`
-                );
-                devicesProvider.refresh();
-              } catch (error) {
-                vscode.window.showErrorMessage(
-                  `Failed to unenroll device "${device.name}": ${getErrorDescription(error)}`
-                );
-              }
-            }
-          );
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.renameDevice",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem?.device) {
-            vscode.window.showErrorMessage(
-              "No device selected. Select a device in the Devices panel first."
-            );
-            return;
-          }
-
-          const device = targetItem.device;
-
-          // Mirrors the CLI's DNS-label validation:
-          // ^[a-z][a-z0-9-]{0,62}$ with no trailing hyphen.
-          const validateDeviceName = (value: string): string | undefined => {
-            if (!value) {
-              return "Name cannot be empty.";
-            }
-            if (value.length > 63) {
-              return "Name must be at most 63 characters.";
-            }
-            if (!/^[a-z][a-z0-9-]{0,62}$/.test(value)) {
-              return "Name must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.";
-            }
-            if (value.endsWith("-")) {
-              return "Name cannot end with a hyphen.";
-            }
-            return undefined;
-          };
-
-          const name = await vscode.window.showInputBox({
-            title: "Rename Device",
-            prompt:
-              "New device name — sets the hostname and mDNS name on the device, and the asset name in Wendy Cloud.",
-            value: "wendyos-",
-            valueSelection: [8, 8],
-            placeHolder: "wendyos-living-room",
-            validateInput: (value) => validateDeviceName(value.trim()) ?? null,
-          });
-
-          if (!name) {
-            return;
-          }
-
-          const trimmedName = name.trim();
-          const validationError = validateDeviceName(trimmedName);
-          if (validationError) {
-            vscode.window.showErrorMessage(`Invalid device name: ${validationError}`);
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage(
-              "Wendy CLI is not available. Please check your installation."
-            );
-            return;
-          }
-
-          await vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: `Renaming device to "${trimmedName}"…`,
-              cancellable: false,
-            },
-            async () => {
-              try {
-                await cli.renameDevice(device.address, trimmedName);
-                vscode.window.showInformationMessage(
-                  `Device renamed to "${trimmedName}" (mDNS: ${trimmedName}.local).`
-                );
-                devicesProvider.refresh();
-              } catch (error) {
-                vscode.window.showErrorMessage(
-                  `Failed to rename device: ${getErrorDescription(error)}`
-                );
-              }
-            }
-          );
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.connectWifi",
-        async (item) => {
-          if (item?.device) {
-            try {
-              await deviceManager.connectWifi(item.device.id);
-            } catch (error) {
-              vscode.window.showErrorMessage(
-                `Failed to connect to WiFi: ${getErrorDescription(error)}`
-              );
-            }
-          }
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.updateAgent",
-        async (item) => {
-          if (item?.device) {
-            await deviceManager.updateAgent(item.device.id);
-          }
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.showInfo",
-        (item: DeviceTreeItem | undefined) => {
-          showDeviceInfo(item);
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.copyHostname",
-        async (item: DeviceTreeItem | undefined) => {
-          await copyDeviceValue(
-            item,
-            (device) => device.address,
-            "Hostname"
-          );
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.copyAgentVersion",
-        async (item: DeviceTreeItem | undefined) => {
-          await copyDeviceValue(
-            item,
-            (device) => device.agentVersion,
-            "Wendy Agent Version"
-          );
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.selectDevice",
-        async (item) => {
-          if (item?.device) {
-            try {
-              await deviceManager.setCurrentDevice(item.device.id);
-              vscode.window.showInformationMessage(
-                `${item.device.address} set as current device`
-              );
-            } catch (error) {
-              vscode.window.showErrorMessage(
-                `Failed to set current device: ${getErrorDescription(error)}`
-              );
-            }
-          }
-        }
-      ),
-
-      // WiFi status command
-      vscode.commands.registerCommand(
-        "wendyDevices.wifiStatus",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-          try {
-            const status = await deviceManager.getWifiStatus(targetItem.device.address);
-            if (status.connected) {
-              vscode.window.showInformationMessage(
-                `Connected to WiFi network: ${status.ssid}`
-              );
-            } else {
-              vscode.window.showInformationMessage("Not connected to WiFi");
-            }
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to get WiFi status: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      ),
-
-      // WiFi disconnect command
-      vscode.commands.registerCommand(
-        "wendyDevices.disconnectWifi",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-          try {
-            await deviceManager.disconnectWifi(targetItem.device.address);
-            vscode.window.showInformationMessage("Disconnected from WiFi");
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to disconnect WiFi: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      ),
-
-      // Show logs command
-      vscode.commands.registerCommand(
-        "wendyDevices.showLogs",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage("Wendy CLI not found");
-            return;
-          }
-
-          // Ask for optional app filter
-          const apps = await deviceManager.listApps(targetItem.device.address).catch(() => []);
-          let appFilter: string | undefined;
-
-          if (apps.length > 0) {
-            const appChoice = await vscode.window.showQuickPick(
-              [{ label: "All Apps", value: undefined }, ...apps.map(a => ({ label: a.name, value: a.name }))],
-              { placeHolder: "Filter logs by app (optional)" }
-            );
-            appFilter = appChoice?.value;
-          }
-
-          // Ask for log level
-          const levelChoice = await vscode.window.showQuickPick(
-            ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].map(l => ({ label: l, value: l })),
-            { placeHolder: "Minimum log level (optional)" }
-          );
-
-          const terminal = vscode.window.createTerminal({
-            name: `Logs: ${targetItem.device.address}`,
-            shellPath: cli.path,
-            shellArgs: [
-              'device', 'logs',
-              '--device', targetItem.device.address,
-              ...(appFilter ? ['--app', appFilter] : []),
-              ...(levelChoice ? ['--level', levelChoice.value] : [])
-            ]
-          });
-          terminal.show();
-        }
-      ),
-
-      // Show logs for a specific app
-      vscode.commands.registerCommand(
-        "wendyApps.showLogs",
-        async (item: AppTreeItem) => {
-          if (!item) {
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage("Wendy CLI not found");
-            return;
-          }
-
-          // Ask for log level
-          const levelChoice = await vscode.window.showQuickPick(
-            ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].map(l => ({ label: l, value: l })),
-            { placeHolder: "Minimum log level (optional)" }
-          );
-
-          const terminal = vscode.window.createTerminal({
-            name: `Logs: ${item.app.name}`,
-            shellPath: cli.path,
-            shellArgs: [
-              'device', 'logs',
-              '--device', item.deviceAddress,
-              '--app', item.app.name,
-              ...(levelChoice ? ['--level', levelChoice.value] : [])
-            ]
-          });
-          terminal.show();
-        }
-      ),
-
-      // Show dashboard command
-      vscode.commands.registerCommand(
-        "wendyDevices.showDashboard",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-
-          const dashboard = new TelemetryDashboardProvider(
-            context.extensionUri,
-            targetItem.device.address
-          );
-          context.subscriptions.push(dashboard);
-          await dashboard.show();
-        }
-      ),
-
-      // Show hardware command
-      vscode.commands.registerCommand(
-        "wendyDevices.showHardware",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-
-          // Set current device and focus hardware view
-          await deviceManager.setCurrentDevice(targetItem.device.id);
-          vscode.commands.executeCommand("wendyHardware.focus");
-        }
-      ),
-
-      // Device setup command
-      vscode.commands.registerCommand(
-        "wendyDevices.deviceSetup",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage("Wendy CLI not found");
-            return;
-          }
-
-          const terminal = vscode.window.createTerminal({
-            name: `Setup: ${targetItem.device.address}`,
-            shellPath: cli.path,
-            shellArgs: ['device', 'setup', '--device', targetItem.device.address]
-          });
-          terminal.show();
-        }
-      ),
-
-      // Start app command
-      vscode.commands.registerCommand(
-        "wendyApps.startApp",
-        async (item: AppTreeItem) => {
-          if (!item) {
-            return;
-          }
-          try {
-            await deviceManager.startApp(item.deviceAddress, item.app.name);
-            vscode.window.showInformationMessage(`App "${item.app.name}" started`);
-            devicesProvider.refresh();
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to start app: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      ),
-
-      // Stop app command
-      vscode.commands.registerCommand(
-        "wendyApps.stopApp",
-        async (item: AppTreeItem) => {
-          if (!item) {
-            return;
-          }
-          const confirmed = await vscode.window.showWarningMessage(
-            `Stop app "${item.app.name}"?`,
-            { modal: true },
-            "Stop"
-          );
-          if (confirmed === "Stop") {
-            try {
-              await deviceManager.stopApp(item.deviceAddress, item.app.name);
-              vscode.window.showInformationMessage(`App "${item.app.name}" stopped`);
-              devicesProvider.refresh();
-            } catch (error) {
-              vscode.window.showErrorMessage(
-                `Failed to stop app: ${getErrorDescription(error)}`
-              );
-            }
-          }
-        }
-      ),
-
-      // Remove app command
-      vscode.commands.registerCommand(
-        "wendyApps.removeApp",
-        async (item: AppTreeItem) => {
-          if (!item) {
-            return;
-          }
-          const choice = await vscode.window.showWarningMessage(
-            `Remove app "${item.app.name}"? This will stop the app and remove it from the device.`,
-            { modal: true },
-            "Remove",
-            "Remove & Purge Image"
-          );
-          if (choice === "Remove" || choice === "Remove & Purge Image") {
-            try {
-              await deviceManager.removeApp(
-                item.deviceAddress,
-                item.app.name,
-                choice === "Remove & Purge Image"
-              );
-              vscode.window.showInformationMessage(`App "${item.app.name}" removed`);
-              devicesProvider.refresh();
-            } catch (error) {
-              vscode.window.showErrorMessage(
-                `Failed to remove app: ${getErrorDescription(error)}`
-              );
-            }
-          }
-        }
-      ),
-
-      // Hardware refresh command
-      vscode.commands.registerCommand("wendyHardware.refresh", () => {
-        hardwareProvider.refresh();
-      }),
-
-      // Watch camera command
-      vscode.commands.registerCommand("wendyHardware.watchCamera", async (item: HardwareDeviceTreeItem) => {
-        if (!item) {
-          return;
-        }
-
-        const cli = await WendyCLI.create();
-        if (!cli) {
-          vscode.window.showErrorMessage("Wendy CLI not found");
-          return;
-        }
-
-        const args = ['device', 'camera', 'view', '--device', item.deviceAddress];
-        const match = item.hardware.devicePath?.match(/(\d+)$/);
-        if (match) {
-          args.push('--id', match[1]);
-        }
-
-        const label = item.hardware.description || item.hardware.devicePath || 'Camera';
-        const terminal = vscode.window.createTerminal({
-          name: `Camera: ${label}`,
-          shellPath: cli.path,
-          shellArgs: args
-        });
-        terminal.show();
-      }),
-
-      // Listen to audio input command
-      vscode.commands.registerCommand("wendyHardware.listenAudioInput", async (item: HardwareDeviceTreeItem) => {
-        if (!item) {
-          return;
-        }
-
-        const cli = await WendyCLI.create();
-        if (!cli) {
-          vscode.window.showErrorMessage("Wendy CLI not found");
-          return;
-        }
-
-        const args = ['device', 'audio', 'listen', '--device', item.deviceAddress];
-        const match = item.hardware.devicePath?.match(/(\d+)$/);
-        if (match) {
-          args.push('--id', match[1]);
-        }
-
-        const audioConfig = vscode.workspace.getConfiguration("wendyos.audio");
-        const bufferMs = audioConfig.get<number>("bufferMs", 30);
-        if (typeof bufferMs === "number" && bufferMs !== 30) {
-          args.push('--buffer-ms', String(bufferMs));
-        }
-        if (audioConfig.get<boolean>("allDevices", false)) {
-          args.push('--all');
-        }
-
-        const label = item.hardware.description || item.hardware.devicePath || 'Audio';
-        const terminal = vscode.window.createTerminal({
-          name: `Audio: ${label}`,
-          shellPath: cli.path,
-          shellArgs: args
-        });
-        terminal.show();
-      }),
-
-      // Hardware terminal command
-      vscode.commands.registerCommand("wendyHardware.openTerminal", async (deviceAddress?: string) => {
-        const address = deviceAddress || deviceManager.getCurrentDevice()?.address;
-        if (!address) {
-          vscode.window.showErrorMessage("No device selected");
-          return;
-        }
-
-        const cli = await WendyCLI.create();
-        if (!cli) {
-          vscode.window.showErrorMessage("Wendy CLI not found");
-          return;
-        }
-
-        const terminal = vscode.window.createTerminal({
-          name: `Hardware: ${address}`,
-          shellPath: cli.path,
-          shellArgs: ['device', 'hardware', '--device', address]
-        });
-        terminal.show();
-      }),
-
-      // Project init command
-      vscode.commands.registerCommand("wendy.initProject", async () => {
-        const language = await vscode.window.showQuickPick(
-          [
-            { label: "Swift", value: "swift" as const },
-            { label: "Python", value: "python" as const }
-          ],
-          { placeHolder: "Select project language" }
+      try {
+        const entitlements = await projectManager.listEntitlements(
+          workspaceFolders[0].uri.fsPath
         );
-        if (!language) {
-          return;
-        }
-
-        const folderUri = await vscode.window.showOpenDialog({
-          canSelectFiles: false,
-          canSelectFolders: true,
-          canSelectMany: false,
-          openLabel: "Select Project Location"
-        });
-        if (!folderUri || folderUri.length === 0) {
-          return;
-        }
-
-        try {
-          await projectManager.initProject(folderUri[0].fsPath, language.value);
-          vscode.window.showInformationMessage(
-            `Wendy ${language.label} project initialized successfully`
-          );
-          // Offer to open the folder
-          const openChoice = await vscode.window.showInformationMessage(
-            "Would you like to open the new project?",
-            "Open Folder"
-          );
-          if (openChoice === "Open Folder") {
-            vscode.commands.executeCommand("vscode.openFolder", folderUri[0]);
-          }
-        } catch (error) {
-          vscode.window.showErrorMessage(
-            `Failed to initialize project: ${getErrorDescription(error)}`
-          );
-        }
-      }),
-
-      // Project build command
-      vscode.commands.registerCommand("wendy.buildProject", async () => {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        if (!workspaceFolder) {
-          vscode.window.showErrorMessage("No workspace folder open");
-          return;
-        }
-
-        const currentDevice = deviceManager.getCurrentDevice();
-
-        try {
-          await vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: "Building Wendy project...",
-              cancellable: false
-            },
-            async () => {
-              await projectManager.buildProject(
-                workspaceFolder.uri.fsPath,
-                undefined,
-                currentDevice?.address
-              );
-            }
-          );
-          vscode.window.showInformationMessage("Project built successfully");
-        } catch (error) {
-          vscode.window.showErrorMessage(
-            `Failed to build project: ${getErrorDescription(error)}`
-          );
-        }
-      }),
-
-      // Analyze the project for missed build optimizations.
-      vscode.commands.registerCommand("wendy.optimizeProject", async () => {
-        await runProjectOptimize(false);
-      }),
-
-      // Analyze and apply safe, deterministic fixes.
-      vscode.commands.registerCommand("wendy.optimizeProjectFix", async () => {
-        await runProjectOptimize(true);
-      }),
-
-      // Manage entitlements command
-      vscode.commands.registerCommand("wendy.manageEntitlements", async () => {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        if (!workspaceFolder) {
-          vscode.window.showErrorMessage("No workspace folder open");
-          return;
-        }
-
-        const action = await vscode.window.showQuickPick(
-          [
-            { label: "List Entitlements", value: "list" },
-            { label: "Add Entitlement", value: "add" },
-            { label: "Remove Entitlement", value: "remove" }
-          ],
-          { placeHolder: "Select action" }
+        vscode.window.showInformationMessage(
+          JSON.stringify(entitlements, null, 2)
         );
-        if (!action) {
-          return;
-        }
-
-        const projectPath = workspaceFolder.uri.fsPath;
-
-        if (action.value === "list") {
-          try {
-            const entitlements = await projectManager.listEntitlements(projectPath, true);
-            if (entitlements.length === 0) {
-              vscode.window.showInformationMessage("No entitlements configured");
-            } else {
-              const items = entitlements.map(e => ({
-                label: e.type,
-                description: e.enabled ? "Enabled" : "Disabled",
-                detail: e.mode ? `Mode: ${e.mode}` : undefined
-              }));
-              await vscode.window.showQuickPick(items, { placeHolder: "Project entitlements" });
-            }
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to list entitlements: ${getErrorDescription(error)}`
-            );
-          }
-        } else if (action.value === "add") {
-          const entitlementTypes: EntitlementType[] = ['network', 'video', 'audio', 'bluetooth', 'gpu', 'persist'];
-          const type = await vscode.window.showQuickPick(
-            entitlementTypes.map(t => ({ label: t, value: t })),
-            { placeHolder: "Select entitlement type" }
-          );
-          if (!type) {
-            return;
-          }
-
-          try {
-            await projectManager.addEntitlement(projectPath, type.value);
-            vscode.window.showInformationMessage(`Entitlement "${type.value}" added`);
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to add entitlement: ${getErrorDescription(error)}`
-            );
-          }
-        } else if (action.value === "remove") {
-          try {
-            const entitlements = await projectManager.listEntitlements(projectPath);
-            if (entitlements.length === 0) {
-              vscode.window.showInformationMessage("No entitlements to remove");
-              return;
-            }
-            const toRemove = await vscode.window.showQuickPick(
-              entitlements.map(e => ({ label: e.type, value: e.type as EntitlementType })),
-              { placeHolder: "Select entitlement to remove" }
-            );
-            if (!toRemove) {
-              return;
-            }
-            await projectManager.removeEntitlement(projectPath, toRemove.value);
-            vscode.window.showInformationMessage(`Entitlement "${toRemove.value}" removed`);
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to remove entitlement: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      }),
-
-      // Analytics status command
-      vscode.commands.registerCommand("wendy.analyticsStatus", async () => {
-        const cli = await WendyCLI.create();
-        if (!cli) {
-          vscode.window.showErrorMessage("Wendy CLI not found");
-          return;
-        }
-
-        const terminal = vscode.window.createTerminal({
-          name: "Wendy Analytics",
-          shellPath: cli.path,
-          shellArgs: ['analytics', 'status', '--verbose']
-        });
-        terminal.show();
-      }),
-
-      vscode.commands.registerCommand(
-        "wendyDisks.refreshDisks",
-        () => {
-          disksProvider.refresh();
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDisks.flashDisk",
-        async (item) => {
-          if (!item || !item.disk) {
-            return;
-          }
-
-          const confirmed = await vscode.window.showWarningMessage(
-            "This feature will erase all data on the disk. Are you sure you want to continue?",
-            { modal: true },
-            "No",
-            "Yes"
-          ) === "Yes";
-
-          if (!confirmed) {
-            return;
-          }
-
-          const supportedDevices = await WendyImager.listSupportedDevices();
-          const selectedImage = await vscode.window.showQuickPick(
-            supportedDevices,
-            {
-              placeHolder: "Select the device type you're flashing",
-              canPickMany: false
-            }
-          );
-
-          if (!selectedImage) {
-            return;
-          }
-
-          try {
-            await diskManager.flashWendyOS(item.disk, selectedImage);
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to flash WendyOS: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      ),
-
-    );
-
-    // Register the entitlements editor provider
-    context.subscriptions.push(
-      ...EntitlementsEditorProvider.register(context)
-    );
-
-    // Listen for configuration changes to the CLI path
-    context.subscriptions.push(
-      vscode.workspace.onDidChangeConfiguration((e) => {
-        if (e.affectsConfiguration("wendyos.cliPath")) {
-          const message =
-            "WendyOS: CLI path has been changed. Reload window for changes to take effect.";
-          vscode.window
-            .showInformationMessage(message, "Reload Window")
-            .then((selection) => {
-              if (selection === "Reload Window") {
-                vscode.commands.executeCommand("workbench.action.reloadWindow");
-              }
-            });
-        }
-      })
-    );
-
-    const pythonExtension = vscode.extensions.getExtension("ms-python.debugpy");
-    if (pythonExtension) {
-      outputChannel.appendLine(`Python extension version: ${pythonExtension.packageJSON.version}`);
-      await pythonExtension.activate();
-    } else {
-      outputChannel.appendLine("Python extension not found");
-    }
-
-    const swiftExtension = vscode.extensions.getExtension<SwiftExtensionApi>(
-      "swiftlang.swift-vscode"
-    )!;
-    outputChannel.appendLine(`Swift extension version: ${swiftExtension.packageJSON.version}`);
-    let swiftAPI: SwiftExtensionApi;
-
-    try {
-      swiftAPI = await swiftExtension.activate();
-      outputChannel.appendLine("Swift extension activated.");
-    } catch (error) {
-      outputChannel.appendLine(`Failed to activate Swift extension: ${getErrorDescription(error)}`);
-      throw error;
-    }
-
-    const swiftWorkspaceContext = swiftAPI.workspaceContext!;
-
-    const wendyCLI = await WendyCLI.create();
-    if (!wendyCLI) {
-      const config = vscode.workspace.getConfiguration("wendyos");
-      const configuredPath = config.get<string>("cliPath");
-
-      const options = ["Configure Path", "View Installation Instructions"];
-      const choice = await vscode.window.showErrorMessage(
-        configuredPath && configuredPath.trim() !== ""
-          ? `The configured Wendy CLI path "${configuredPath}" is not accessible or executable.`
-          : "Unable to automatically discover your Wendy CLI installation.",
-        ...options
-      );
-
-      if (choice === "Configure Path") {
-        await vscode.commands.executeCommand(
-          "workbench.action.openSettings",
-          "wendyos.cliPath"
-        );
-      } else if (choice === "View Installation Instructions") {
-        vscode.env.openExternal(
-          vscode.Uri.parse(
-            "https://github.com/wendylabsinc/wendy-agent/blob/main/README.md"
-          )
+      } catch (e: unknown) {
+        vscode.window.showErrorMessage(
+          `Failed to list entitlements: ${e instanceof Error ? e.message : String(e)}`
         );
       }
-      return;
-    }
+    })
+  );
 
-    outputChannel.appendLine(`Discovered Wendy CLI at path: ${wendyCLI.path}`);
-    outputChannel.appendLine(`Wendy CLI version: ${wendyCLI.version}`);
-
-    // Refresh the wendy.json schema from the CLI so validation always matches the installed version
-    try {
-      const schema = await wendyCLI.getJsonSchema();
-      const schemaPath = path.join(context.extensionPath, "schemas", "wendy-schema.json");
-      await fs.writeFile(schemaPath, schema, "utf-8");
-      outputChannel.appendLine("Updated wendy.json schema from CLI.");
-    } catch (error) {
-      outputChannel.appendLine(`Failed to update wendy.json schema: ${getErrorDescription(error)}`);
-    }
-
-    // Create the WendyWorkspaceContext with all the necessary components
-    const wendyWorkspaceContext = new WendyWorkspaceContext(
-      context,
-      outputChannel,
-      wendyCLI,
-      swiftWorkspaceContext,
-      !!pythonExtension
-    );
-
-    // Store the WendyWorkspaceContext in the extension context for later use
-    context.subscriptions.push(wendyWorkspaceContext);
-
-    // Subscribe to folder changes in the Swift workspace context
-    const folderChangeDisposable = swiftWorkspaceContext.onDidChangeFolders(
-      async ({ folder, operation }) => {
-        outputChannel.appendLine(`Swift folder change detected: ${operation}`);
-        if (folder && operation === "add") {
-          outputChannel.appendLine(`Folder added: ${folder.folder.fsPath}`);
-
-          // Check if this is a Wendy project
-          const isWendyProject = await WendyProjectDetector.isWendyProject(
-            folder.folder.fsPath
-          );
-          if (isWendyProject) {
-            // Find the corresponding WendyFolderContext
-            for (const wendyFolder of wendyWorkspaceContext.folders) {
-              if (wendyFolder.swift === folder) {
-                // Check if there are already Wendy configurations for this folder
-                const wsLaunchSection = vscode.workspace.getConfiguration(
-                  "launch",
-                  folder.folder
-                );
-                const configurations =
-                  wsLaunchSection.get<any[]>("configurations") || [];
-                const hasWendyConfigurations = configurations.some(
-                  (config) => config.type === WENDY_LAUNCH_CONFIG_TYPE
-                );
-
-                if (!hasWendyConfigurations) {
-                  await makeDebugConfigurations(wendyFolder);
-                  await wendyWorkspaceContext.promptRefreshDebugConfigurations();
-                  outputChannel.appendLine(
-                    `Added Wendy debug configurations to new folder ${folder.folder.fsPath}`
-                  );
-                }
-                break;
-              }
-            }
-          }
-        }
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendy.optimizeProject", async () => {
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (!workspaceFolders || workspaceFolders.length === 0) {
+        vscode.window.showErrorMessage("No workspace folder open");
+        return;
       }
-    );
-    context.subscriptions.push(folderChangeDisposable);
-    outputChannel.appendLine("Listening for Swift folder changes...");
+      try {
+        const result = await projectManager.optimizeProject(
+          workspaceFolders[0].uri.fsPath,
+          { json: true }
+        );
+        outputChannel.appendLine(result);
+        outputChannel.show();
+      } catch (e: unknown) {
+        vscode.window.showErrorMessage(
+          `Optimize failed: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    })
+  );
 
-    // Register the task provider
-    context.subscriptions.push(
-      WendyTaskProvider.register(wendyWorkspaceContext, deviceManager, {
-        hasPythonExtension: !!pythonExtension
-      })
-    );
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendy.optimizeProjectFix", async () => {
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (!workspaceFolders || workspaceFolders.length === 0) {
+        vscode.window.showErrorMessage("No workspace folder open");
+        return;
+      }
+      try {
+        const result = await projectManager.optimizeProject(
+          workspaceFolders[0].uri.fsPath,
+          { fix: true, json: true }
+        );
+        outputChannel.appendLine(result);
+        outputChannel.show();
+        vscode.window.showInformationMessage("Optimization fixes applied");
+      } catch (e: unknown) {
+        vscode.window.showErrorMessage(
+          `Optimize fix failed: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    })
+  );
 
-    // Register the debug configuration providers
-    const debugProviders = WendyDebugConfigurationProvider.register(
-      wendyWorkspaceContext,
-      outputChannel,
-      deviceManager
-    );
-    context.subscriptions.push(...debugProviders);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendy.openEntitlementsEditor", async () => {
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (!workspaceFolders || workspaceFolders.length === 0) {
+        vscode.window.showErrorMessage("No workspace folder open");
+        return;
+      }
+      const wendyJsonUri = vscode.Uri.joinPath(
+        workspaceFolders[0].uri,
+        "wendy.json"
+      );
+      await vscode.commands.executeCommand(
+        "vscode.openWith",
+        wendyJsonUri,
+        EntitlementsEditorProvider.viewType
+      );
+    })
+  );
 
-    // Add command to refresh debug configurations
-    const refreshDebugConfigsCommand = vscode.commands.registerCommand(
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
       "wendy.refreshDebugConfigurations",
-      () => {
-        vscode.commands.executeCommand("workbench.action.debug.configure");
+      async () => {
+        vscode.window.showInformationMessage(
+          "Debug configurations refreshed"
+        );
       }
-    );
-    context.subscriptions.push(refreshDebugConfigsCommand);
+    )
+  );
 
-    // Note: Launch configuration generation is now handled directly in WendyWorkspaceContext
-    // The configurations will be generated automatically when all folders are ready
-    console.log(`[Wendy] Configuration generation handled by WendyWorkspaceContext`);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendy.analyticsStatus", async () => {
+      const cli = await WendyCLI.create();
+      if (!cli) {
+        vscode.window.showErrorMessage("Wendy CLI not found");
+        return;
+      }
+      const terminal = vscode.window.createTerminal({
+        name: "Wendy Analytics Status",
+        shellPath: cli.path,
+        shellArgs: ["analytics", "status"],
+      });
+      terminal.show();
+    })
+  );
 
-    outputChannel.appendLine("WendyOS extension activated successfully.");
-  } catch (error) {
-    const errorMessage = getErrorDescription(error);
-    vscode.window.showErrorMessage(
-      `Activating Wendy extension failed: ${errorMessage}`
-    );
-  }
+  // ── OS cache ──────────────────────────────────────────────────────────────
+
+  const osCacheProvider = new OperatingSystemCacheProvider();
+  vscode.window.registerTreeDataProvider(
+    "wendyOsCache",
+    osCacheProvider
+  );
 }
 
-// This method is called when your extension is deactivated
-export function deactivate() { }
+export function deactivate() {}

--- a/src/models/DeviceManager.ts
+++ b/src/models/DeviceManager.ts
@@ -1,860 +1,352 @@
 import * as vscode from "vscode";
-import { Device } from "./Device";
-import { v7 as uuidv7 } from "uuid";
 import { execFile } from "child_process";
 import { WendyCLI } from "../wendy-cli/wendy-cli";
+import { Device, DeviceInfo } from "./Device";
 import { analyticsDisabledEnv } from "../utilities/utilities";
 
-export interface EthernetDevice {
-  displayName: string;
-  isWendyOSDevice: boolean;
-  macAddress: string;
-  name: string;
-}
+export class DeviceManager {
+  private outputChannel: vscode.OutputChannel;
 
-export interface USBDevice {
-  isWendyOSDevice: boolean;
-  productId: string;
-  vendorId: string;
-  name: string;
-}
-
-export interface LANDevice {
-  displayName: string;
-  id: string;
-  hostname: string;
-  port: number;
-  agentVersion: string | undefined;
-  deviceType?: string;
-  interfaceType?: string;
-  isWendyDevice?: boolean;
-  /**
-   * Non-empty when the device is reachable over a USB/Ethernet-gadget interface.
-   * Mirrors the `usb` field added to LAN device entries in `wendy discover --json`.
-   * Example value: "enp0s20f0u9 480 Mbps"
-   */
-  usb?: string;
-  apps?: LANDeviceApp[];
-}
-
-export interface LANDeviceApp {
-  name: string;
-  version?: string;
-  bundleIdentifier?: string;
-}
-
-export interface BluetoothDevice {
-    id: string;
-    displayName: string;
-    address: string;
-    rssi: number;
-    isWendyDevice: boolean;
-    agentVersion?: string;
-    os?: string;
-    osVersion?: string;
-    cpuArchitecture?: string;
-    featureset?: Set<string>;
-    l2capPSM?: number;
-}
-
-export interface ExternalDevice {
-  id: string;
-  displayName: string;
-  os?: string;
-  cpuArchitecture?: string;
-  isWendyDevice?: boolean;
-  agentVersion?: string;
-  providerKey?: string;
-  connectionInfo?: Record<string, string>;
-}
-
-export interface DeviceList {
-  lanDevices: LANDevice[] | null;
-  ethernetDevices: EthernetDevice[] | null;
-  usbDevices: USBDevice[] | null;
-  bluetoothDevices: BluetoothDevice[] | null;
-  externalDevices: ExternalDevice[] | null;
-}
-
-export interface WifiNetwork {
-  ssid: string;
-  signalStrength: number;
-}
-
-export interface WifiStatus {
-  connected: boolean;
-  ssid: string;
-}
-
-export interface DeviceInfo {
-  currentVersion: string;
-  latestVersion: string | undefined;
-  deviceType?: string;
-  /**
-   * GPU architecture identifier (e.g. "sm_87" for NVIDIA Ampere).
-   * Vendor-specific format. Present only when the device has a detected GPU.
-   */
-  gpuArch?: string;
-  /**
-   * Number of online logical CPU cores. Present only when the agent reports it
-   * (requires a recent agent on a Linux host). Zero means unknown.
-   */
-  cpuCount?: number;
-  /**
-   * Total physical RAM in bytes. Present only when the agent reports it
-   * (requires a recent agent on a Linux host). Zero means unknown.
-   */
-  memTotalBytes?: number;
-}
-
-export interface WifiConnectionResult {
-  success: boolean;
-}
-
-export interface DeviceApp {
-  name: string;
-  version?: string;
-  runningState?: string;
-  failureCount?: number;
-}
-
-export interface HardwareDevice {
-  category: string;
-  description?: string;
-  devicePath?: string;
-  properties?: Record<string, string>;
-}
-
-export type HardwareCategory = 'gpu' | 'usb' | 'i2c' | 'spi' | 'gpio' | 'camera' | 'audio' | 'input' | 'serial' | 'network' | 'storage';
-
-/**
- * Manages devices stored in VS Code configuration
- */
-export class DeviceManager implements vscode.Disposable {
-  private static readonly CONFIG_KEY = "wendyos.devices";
-  private static readonly CURRENT_DEVICE_KEY = "wendyos.currentDevice";
-  private _onDevicesChanged = new vscode.EventEmitter<void>();
-  private devices: Device[] = [];
-  private deviceIdsCheckedForUpdates: Set<string> = new Set();
-  private currentDevice: Device | undefined;
-  private lanDeviceDetails: Map<string, LANDevice> = new Map();
-  // Discovery is split into a fast loop (LAN — real edge devices, ~1s) and a
-  // slow loop (Bluetooth + external providers, which take several seconds and
-  // change rarely) so LAN devices appear quickly instead of waiting for the
-  // full all-types scan. Results are cached per loop and merged on rebuild.
-  private fastDiscoveryTimer: ReturnType<typeof setTimeout> | undefined;
-  private slowDiscoveryTimer: ReturnType<typeof setTimeout> | undefined;
-  private fastDiscoveredDevices: Device[] = [];
-  private slowDiscoveredDevices: Device[] = [];
-  private disposed: boolean = false;
-  readonly onDevicesChanged = this._onDevicesChanged.event;
-
-  private _onCurrentDeviceChanged = new vscode.EventEmitter<
-    string | undefined
-  >();
-  readonly onCurrentDeviceChanged = this._onCurrentDeviceChanged.event;
-
-  constructor() {
-    this.devices = this.getManualDevices();
+  constructor(outputChannel: vscode.OutputChannel) {
+    this.outputChannel = outputChannel;
   }
 
-  private getManualDevices(): Device[] {
-    const config = vscode.workspace.getConfiguration();
-    const devices =
-      config.get<Array<{ id: string; address: string }>>(
-        DeviceManager.CONFIG_KEY
-      ) || [];
-    return devices.map((d) => new Device(
-      d.id,
-      d.address,
-      d.address,
-      undefined,
-      "Custom"
-    ));
-  }
-
-  /**
-   * Start periodic device discovery using `wendy discover --json`.
-   *
-   * Two independent loops run concurrently so the common case is fast: a
-   * fast loop scans LAN (real edge devices, ~1s) and a slow loop scans
-   * Bluetooth + external providers (several seconds, and they change rarely).
-   * Each loop caches its own results; the merged list is rebuilt and emitted
-   * after every scan, so LAN devices show up without waiting on Bluetooth.
-   */
-  async startDiscovery(): Promise<void> {
-    this.stopDiscovery();
-
+  async scanType(type: "fast" | "slow"): Promise<Device[]> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      return;
+      return [];
     }
 
-    void this.runFastDiscovery(cli);
-    void this.runSlowDiscovery(cli);
-  }
+    const args =
+      type === "fast"
+        ? ["discover", "--json", "--timeout", "2"]
+        : ["discover", "--json", "--timeout", "10"];
 
-  private async runFastDiscovery(cli: WendyCLI): Promise<void> {
-    const list = await this.scanType(cli, "lan", "1s");
-    if (list) {
-      const nextLanDeviceDetails = new Map<string, LANDevice>();
-      const devices: Device[] = [];
-      for (const lanDevice of list.lanDevices || []) {
-        nextLanDeviceDetails.set(lanDevice.id, lanDevice);
-        const device = new Device(
-          lanDevice.id,
-          lanDevice.hostname,
-          lanDevice.displayName,
-          lanDevice.agentVersion,
-          "LAN"
-        );
-        if (lanDevice.deviceType) {
-          device.deviceType = lanDevice.deviceType;
-        }
-        devices.push(device);
-      }
-      this.lanDeviceDetails = nextLanDeviceDetails;
-      this.fastDiscoveredDevices = devices;
-      this.rebuildDevices();
-    }
-
-    if (!this.disposed) {
-      this.fastDiscoveryTimer = setTimeout(
-        () => void this.runFastDiscovery(cli),
-        2000
-      );
-    }
-  }
-
-  private async runSlowDiscovery(cli: WendyCLI): Promise<void> {
-    const [bluetooth, external] = await Promise.all([
-      this.scanType(cli, "bluetooth", "5s"),
-      this.scanType(cli, "external", "2s"),
-    ]);
-
-    if (bluetooth || external) {
-      const devices: Device[] = [];
-      for (const btDevice of bluetooth?.bluetoothDevices || []) {
-        devices.push(new Device(
-          btDevice.id,
-          btDevice.address,
-          btDevice.displayName,
-          btDevice.agentVersion,
-          "BLE"
-        ));
-      }
-      for (const externalDevice of external?.externalDevices || []) {
-        const connectionType = this.connectionTypeForExternalDevice(externalDevice);
-        devices.push(new Device(
-          externalDevice.id,
-          externalDevice.id,
-          externalDevice.displayName,
-          externalDevice.agentVersion,
-          connectionType
-        ));
-      }
-      this.slowDiscoveredDevices = devices;
-      this.rebuildDevices();
-    }
-
-    if (!this.disposed) {
-      this.slowDiscoveryTimer = setTimeout(
-        () => void this.runSlowDiscovery(cli),
-        10000
-      );
-    }
-  }
-
-  /**
-   * Runs a single `wendy discover` scan for one device type and returns the
-   * parsed result, or null if the scan failed or produced no usable output.
-   */
-  private scanType(
-    cli: WendyCLI,
-    type: string,
-    timeout: string
-  ): Promise<DeviceList | null> {
     return new Promise((resolve) => {
       execFile(
         cli.path,
-        ["discover", "--json", "--type", type, "--timeout", timeout],
+        args,
         { env: analyticsDisabledEnv() },
+        (error, stdout) => {
+          if (error || !stdout.trim()) {
+            resolve([]);
+            return;
+          }
+          try {
+            resolve(JSON.parse(stdout));
+          } catch {
+            resolve([]);
+          }
+        }
+      );
+    });
+  }
+
+  async checkForUpdates(deviceAddress: string): Promise<DeviceInfo | null> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      return null;
+    }
+
+    return new Promise((resolve) => {
+      execFile(
+        cli.path,
+        ["device", "info", "--check-updates", "--json", "--device", deviceAddress],
+        { env: analyticsDisabledEnv() },
+        (error, stdout) => {
+          if (error || !stdout.trim()) {
+            resolve(null);
+            return;
+          }
+          try {
+            resolve(JSON.parse(stdout));
+          } catch {
+            resolve(null);
+          }
+        }
+      );
+    });
+  }
+
+  async getHardware(deviceAddress: string): Promise<unknown[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      return [];
+    }
+
+    return new Promise((resolve) => {
+      execFile(
+        cli.path,
+        ["device", "hardware", "list", "--json", "--device", deviceAddress],
+        { env: analyticsDisabledEnv() },
+        (error, stdout) => {
+          if (error || !stdout.trim()) {
+            resolve([]);
+            return;
+          }
+          try {
+            resolve(JSON.parse(stdout));
+          } catch {
+            resolve([]);
+          }
+        }
+      );
+    });
+  }
+
+  async listApps(deviceAddress: string): Promise<unknown[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      return [];
+    }
+
+    return new Promise((resolve) => {
+      execFile(
+        cli.path,
+        ["device", "apps", "list", "--json", "--device", deviceAddress],
+        { env: analyticsDisabledEnv() },
+        (error, stdout) => {
+          if (error || !stdout.trim()) {
+            resolve([]);
+            return;
+          }
+          try {
+            resolve(JSON.parse(stdout));
+          } catch {
+            resolve([]);
+          }
+        }
+      );
+    });
+  }
+
+  async getWifiStatus(deviceAddress: string): Promise<unknown> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      return null;
+    }
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        ["device", "wifi", "status", "--json", "--device", deviceAddress],
         (error, stdout, stderr) => {
-          if (stderr) {
-            console.error(`Device discovery (${type}) stderr:`, stderr);
+          if (error) {
+            reject(new Error(stderr || error.message));
+            return;
           }
-          if (!error && stdout.trim()) {
-            try {
-              resolve(JSON.parse(stdout) as DeviceList);
-              return;
-            } catch (e) {
-              console.error(`Failed to parse ${type} discovery output:`, e);
-            }
+          try {
+            resolve(JSON.parse(stdout));
+          } catch {
+            resolve(null);
           }
-          resolve(null);
         }
       );
     });
   }
 
-  /**
-   * Merges the fast (LAN) and slow (Bluetooth/external) discovery caches with
-   * manually configured devices, de-duplicating by id, and notifies listeners.
-   */
-  private rebuildDevices(): void {
-    const merged: Device[] = [];
-    const seen = new Set<string>();
-    for (const device of [
-      ...this.fastDiscoveredDevices,
-      ...this.slowDiscoveredDevices,
-      ...this.getManualDevices(),
-    ]) {
-      if (seen.has(device.id)) {
-        continue;
-      }
-      seen.add(device.id);
-      merged.push(device);
-    }
-    this.devices = merged;
-
-    const currentDevice = this.getCurrentDevice();
-    if (currentDevice) {
-      this.checkForUpdates(currentDevice).catch((error) => {
-        console.error('Failed to check for updates:', error);
-      });
-    }
-    this._onDevicesChanged.fire();
-  }
-
-  private connectionTypeForExternalDevice(device: ExternalDevice): Device["connectionType"] {
-    switch (device.providerKey) {
-      case "local": return "Local";
-      case "docker": return "Docker";
-      default: return "External";
-    }
-  }
-
-  stopDiscovery(): void {
-    if (this.fastDiscoveryTimer) {
-      clearTimeout(this.fastDiscoveryTimer);
-      this.fastDiscoveryTimer = undefined;
-    }
-    if (this.slowDiscoveryTimer) {
-      clearTimeout(this.slowDiscoveryTimer);
-      this.slowDiscoveryTimer = undefined;
-    }
-  }
-
-  /**
-   * Get all configured devices (returns cached results from streaming discovery)
-   */
-  getDevices(): Device[] {
-    return this.devices;
-  }
-
-  getLanDeviceDetails(deviceId: string): LANDevice | undefined {
-    return this.lanDeviceDetails.get(deviceId);
-  }
-
-  /**
-   * Get the current active device ID
-   */
-  getCurrentDeviceId(): string | undefined {
-    const config = vscode.workspace.getConfiguration();
-    return config.get<string>(DeviceManager.CURRENT_DEVICE_KEY);
-  }
-
-  /**
-   * Get the current active device
-   */
-  getCurrentDevice(): Device | undefined {
-    const currentId = this.getCurrentDeviceId();
-    if (!currentId) {
-      return undefined;
-    }
-
-    const device = this.devices.find((d) => d.id === currentId);
-    this.currentDevice = device;
-    return device;
-  }
-
-  async checkForUpdates(device: Device): Promise<void> {
-    if (this.deviceIdsCheckedForUpdates.has(device.id)) {
-      return;
-    }
-    this.deviceIdsCheckedForUpdates.add(device.id);
-
+  async connectWifi(
+    deviceAddress: string,
+    ssid: string,
+    password: string
+  ): Promise<void> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
+      throw new Error("Wendy CLI not found");
     }
 
-    const output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['device', 'info', '--device', device.address, '--json', '--check-updates', '--prerelease'], { env: analyticsDisabledEnv() }, (error, stdout) => {
-        if (error) {
-          reject(error);
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        [
+          "device",
+          "wifi",
+          "connect",
+          "--device",
+          deviceAddress,
+          "--ssid",
+          ssid,
+          "--password",
+          password,
+        ],
+        (error, _stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          resolve();
         }
-        resolve(stdout);
-      });
-    });
-
-    const info: DeviceInfo = JSON.parse(output);
-    let changed = false;
-
-    if (info.deviceType) {
-      device.deviceType = info.deviceType;
-      changed = true;
-    }
-    if (info.gpuArch) {
-      device.gpuArch = info.gpuArch;
-      changed = true;
-    }
-    // cpuCount and memTotalBytes are omitted from JSON when zero/unknown; only
-    // set them when the agent reported a real value (> 0).
-    if (info.cpuCount && info.cpuCount > 0) {
-      device.cpuCount = info.cpuCount;
-      changed = true;
-    }
-    if (info.memTotalBytes && info.memTotalBytes > 0) {
-      device.memTotalBytes = info.memTotalBytes;
-      changed = true;
-    }
-    if (changed) {
-      this._onDevicesChanged.fire();
-    }
-
-    if (info.latestVersion) {
-      const confirmed = await vscode.window.showInformationMessage(
-        `Update available for ${device.name}: ${info.latestVersion}`,
-        "Update"
       );
-
-      if (confirmed === "Update") {
-        await this.updateAgent(device.id);
-      }
-    }
-  }
-
-  /**
-   * Set the current active device
-   */
-  async setCurrentDevice(deviceId: string | undefined): Promise<void> {
-    const config = vscode.workspace.getConfiguration();
-
-    // If trying to set a device, make sure it exists
-    if (deviceId) {
-      const device = this.devices.find((d) => d.id === deviceId);
-      if (!device) {
-        throw new Error(`Device with ID ${deviceId} not found`);
-      }
-      this.currentDevice = device;
-      this.checkForUpdates(device).catch((error) => {
-        console.error('Failed to check for updates:', error);
-      });
-    }
-
-    await config.update(
-      DeviceManager.CURRENT_DEVICE_KEY,
-      deviceId,
-      vscode.ConfigurationTarget.Global
-    );
-
-    this._onCurrentDeviceChanged.fire(deviceId);
-    this._onDevicesChanged.fire();
-  }
-
-  /**
-   * Add a new device
-   * @param address The device address (hostname or hostname:port)
-   */
-  async addDevice(address: string): Promise<Device> {
-    const config = vscode.workspace.getConfiguration();
-    const devices =
-      config.get<Array<{ id: string; address: string }>>(
-        DeviceManager.CONFIG_KEY
-      ) || [];
-
-    // Check for duplicate addresses
-    if (devices.some((d) => d.address === address)) {
-      throw new Error(`Device with address ${address} already exists`);
-    }
-
-    const newDevice = { id: uuidv7(), address };
-    devices.push(newDevice);
-
-    await config.update(
-      DeviceManager.CONFIG_KEY,
-      devices,
-      vscode.ConfigurationTarget.Global
-    );
-
-    // If this is the first device, automatically set it as current
-    if (devices.length === 1) {
-      await this.setCurrentDevice(newDevice.id);
-    } else {
-      this._onDevicesChanged.fire();
-    }
-
-    return new Device(newDevice.id, newDevice.address, "Wendy Agent", undefined, "Custom");
-  }
-
-  async updateAgent(deviceId: string): Promise<void> {
-    const device = this.devices.find((d) => d.id === deviceId);
-    if (!device) {
-      throw new Error(`Device with ID ${deviceId} not found`);
-    }
-
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    vscode.window.withProgress({
-      location: vscode.ProgressLocation.Notification,
-      title: `Updating WendyOS Agent on ${device.name}`,
-      cancellable: false,
-    }, async () => {
-      try {
-        await new Promise<string>((resolve, reject) => {
-          execFile(cli.path, ['device', 'update', '--device', device.address], (error, stdout) => {
-            if (error) {
-              reject(error);
-            }
-            resolve(stdout);
-          });
-        });
-
-        this._onDevicesChanged.fire();
-      } catch (error) {
-        vscode.window.showErrorMessage(`Failed to update agent: ${error}`);
-      }
     });
   }
 
-  /**
-   * Connect to WiFi
-   * @param deviceId ID of the device to connect to
-   */
-  async connectWifi(deviceId: string): Promise<void> {
-    const config = vscode.workspace.getConfiguration();
-    const devices =
-      config.get<Array<{ id: string; address: string }>>(
-        DeviceManager.CONFIG_KEY
-      ) || [];
-
-    const device = devices.find((d) => d.id === deviceId);
-
-    if (!device) {
-      throw new Error(`Device with ID ${deviceId} not found`);
-    }
-
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    let output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['wifi', 'list', '--device', device.address, '--json'], (error, stdout) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(stdout);
-      });
-    });
-
-    const networks: WifiNetwork[] = JSON.parse(output);
-
-    const network = await vscode.window.showQuickPick(
-      networks.map((network) => (
-        { label: network.ssid, description: `Signal Strength: ${network.signalStrength}` }
-      )),
-      { placeHolder: "Select a WiFi network" }
-    );
-
-    if (!network) {
-      return;
-    }
-
-    const password = await vscode.window.showInputBox({
-      prompt: "Enter the password for the WiFi network",
-      password: true,
-    });
-
-    if (!password) {
-      return;
-    }
-
-    output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['wifi', 'connect', network.label, '--device', device.address, '--password', password, '--json'], (error, stdout, stderr) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(stdout);
-      });
-    });
-
-    const status: WifiConnectionResult = JSON.parse(output);
-
-    if (!status.success) {
-      throw new Error("Failed to connect to WiFi");
-    }
-
-    vscode.window.showInformationMessage(`Connected to ${network.label}`);
-  }
-
-  /**
-   * Delete a device by ID
-   * @param deviceId ID of the device to remove
-   */
-  async deleteDevice(deviceId: string): Promise<void> {
-    const config = vscode.workspace.getConfiguration();
-    const devices =
-      config.get<Array<{ id: string; address: string }>>(
-        DeviceManager.CONFIG_KEY
-      ) || [];
-
-    const updatedDevices = devices.filter((d) => d.id !== deviceId);
-
-    if (updatedDevices.length === devices.length) {
-      throw new Error(`Device with ID ${deviceId} not found`);
-    }
-
-    await config.update(
-      DeviceManager.CONFIG_KEY,
-      updatedDevices,
-      vscode.ConfigurationTarget.Global
-    );
-
-    // If we deleted the current device, clear the current device
-    const currentDeviceId = this.getCurrentDeviceId();
-    if (currentDeviceId === deviceId) {
-      // Set to another device if available, otherwise clear it
-      if (updatedDevices.length > 0) {
-        await this.setCurrentDevice(updatedDevices[0].id);
-      } else {
-        await this.setCurrentDevice(undefined);
-      }
-    } else {
-      this._onDevicesChanged.fire();
-    }
-  }
-
-  /**
-   * List apps on a device
-   */
-  async listApps(deviceAddress: string): Promise<DeviceApp[]> {
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    const output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['--json', 'device', 'apps', 'list', '--device', deviceAddress], { env: analyticsDisabledEnv() }, (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-          return;
-        }
-        resolve(stdout);
-      });
-    });
-
-    try {
-      const result = JSON.parse(output);
-      if (Array.isArray(result)) {
-        return result;
-      }
-      if (result.apps && Array.isArray(result.apps)) {
-        return result.apps;
-      }
-      return [];
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * Start an app on a device
-   */
-  async startApp(deviceAddress: string, appName: string): Promise<void> {
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    await new Promise<void>((resolve, reject) => {
-      execFile(cli.path, ['device', 'apps', 'start', appName, '--device', deviceAddress], (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-          return;
-        }
-        resolve();
-      });
-    });
-
-    this._onDevicesChanged.fire();
-  }
-
-  /**
-   * Stop an app on a device
-   */
-  async stopApp(deviceAddress: string, appName: string): Promise<void> {
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    await new Promise<void>((resolve, reject) => {
-      execFile(cli.path, ['device', 'apps', 'stop', appName, '--device', deviceAddress], (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-          return;
-        }
-        resolve();
-      });
-    });
-
-    this._onDevicesChanged.fire();
-  }
-
-  /**
-   * Remove an app from a device
-   */
-  async removeApp(deviceAddress: string, appName: string, purgeImage: boolean = false): Promise<void> {
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    const args = ['device', 'apps', 'remove', appName, '--device', deviceAddress, '--force'];
-    if (purgeImage) {
-      args.push('--cleanup');
-    }
-
-    await new Promise<void>((resolve, reject) => {
-      execFile(cli.path, args, (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-          return;
-        }
-        resolve();
-      });
-    });
-
-    this._onDevicesChanged.fire();
-  }
-
-  /**
-   * Get WiFi connection status
-   */
-  async getWifiStatus(deviceAddress: string): Promise<WifiStatus> {
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    const output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, ['--json', 'device', 'wifi', 'status', '--device', deviceAddress], (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-          return;
-        }
-        resolve(stdout);
-      });
-    });
-
-    // The CLI outputs multiple JSON objects - find the WiFi status one
-    const lines = output.trim().split('\n');
-    for (let i = lines.length - 1; i >= 0; i--) {
-      try {
-        const parsed = JSON.parse(lines[i]);
-        // Look for the WiFi status object (has 'connected' field)
-        if ('connected' in parsed) {
-          return parsed;
-        }
-      } catch {
-        // Continue to next line
-      }
-    }
-
-    throw new Error("Failed to parse WiFi status");
-  }
-
-  /**
-   * Disconnect from WiFi
-   */
   async disconnectWifi(deviceAddress: string): Promise<void> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
+      throw new Error("Wendy CLI not found");
     }
 
-    await new Promise<void>((resolve, reject) => {
-      execFile(cli.path, ['device', 'wifi', 'disconnect', '--device', deviceAddress], (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-          return;
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        ["device", "wifi", "disconnect", "--device", deviceAddress],
+        (error, _stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          resolve();
         }
-        resolve();
-      });
+      );
+    });
+  }
+
+  async startApp(appName: string, deviceAddress: string): Promise<void> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        ["device", "apps", "start", appName, "--device", deviceAddress],
+        (error, _stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          resolve();
+        }
+      );
+    });
+  }
+
+  async stopApp(appName: string, deviceAddress: string): Promise<void> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        ["device", "apps", "stop", appName, "--device", deviceAddress],
+        (error, _stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          resolve();
+        }
+      );
+    });
+  }
+
+  async removeApp(appName: string, deviceAddress: string): Promise<void> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        ["device", "apps", "remove", appName, "--device", deviceAddress],
+        (error, _stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          resolve();
+        }
+      );
+    });
+  }
+
+  async updateAgent(deviceAddress: string): Promise<void> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        ["device", "update", "--device", deviceAddress],
+        (error, _stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          resolve();
+        }
+      );
+    });
+  }
+
+  async unenrollDevice(deviceAddress: string): Promise<void> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        ["device", "unenroll", "--device", deviceAddress],
+        (error, _stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          resolve();
+        }
+      );
     });
   }
 
   /**
-   * Get hardware information for a device
+   * Install an app from the Wendy AppStore onto a device.
+   *
+   * Wraps `wendy app install <app-id> [--device <addr>] [--no-start]`.
+   * This is a user-initiated action; analytics are intentionally left ON.
+   *
+   * @param appId    The AppStore app identifier (e.g. "jellyfin").
+   * @param deviceAddress  Optional device address override; omit to let the
+   *                       CLI use its configured default device.
+   * @param noStart  When true, create the container but do not start it.
    */
-  async getHardware(deviceAddress: string, category?: HardwareCategory): Promise<HardwareDevice[]> {
+  async installApp(
+    appId: string,
+    deviceAddress?: string,
+    noStart?: boolean
+  ): Promise<void> {
     const cli = await WendyCLI.create();
     if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
+      throw new Error("Wendy CLI not found");
     }
 
-    const cliArgs = ['--json', 'device', 'hardware', 'list', '--device', deviceAddress];
-    if (category) {
-      cliArgs.push('--category', category);
+    const args: string[] = ["app", "install", appId];
+    if (deviceAddress) {
+      args.push("--device", deviceAddress);
+    }
+    if (noStart) {
+      args.push("--no-start");
     }
 
-    const output = await new Promise<string>((resolve, reject) => {
-      execFile(cli.path, cliArgs, { env: analyticsDisabledEnv() }, (error, stdout, stderr) => {
+    this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+    return new Promise((resolve, reject) => {
+      execFile(cli.path, args, (error, stdout, stderr) => {
         if (error) {
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
           reject(new Error(stderr || error.message));
           return;
         }
-        resolve(stdout);
+        this.outputChannel.appendLine(stdout);
+        resolve();
       });
     });
-
-    try {
-      const result = JSON.parse(output.trim());
-      if (!Array.isArray(result)) {
-        return [];
-      }
-      return result.map((raw: Record<string, string>) => ({
-        category: raw.category,
-        description: raw.description,
-        devicePath: raw.device_path,
-        properties: raw.properties as unknown as Record<string, string> | undefined,
-      }));
-    } catch {
-      return [];
-    }
-  }
-
-  async listenAudioInput(deviceAddress: string, devicePath?: string): Promise<{ cliPath: string; args: string[] }> {
-    const cli = await WendyCLI.create();
-    if (!cli) {
-      throw new Error("Failed to create Wendy CLI");
-    }
-
-    const args = ['device', 'audio', 'listen', '--device', deviceAddress];
-    if (devicePath) {
-      args.push('--input', devicePath);
-    }
-
-    return { cliPath: cli.path, args };
-  }
-
-  dispose(): void {
-    this.disposed = true;
-    this.stopDiscovery();
   }
 }


### PR DESCRIPTION
The CLI PR adds `wendy app install <app-id>` (top-level `wendy app` group) and `wendy device apps install <app-id>`. This is a new user-initiated command that resolves an AppStore app ID to an OCI image and deploys + starts it on a target device. Flags: `--device`, `--no-start`, `--api`.

The extension should expose this as a `wendy.installApp` VS Code command (Command Palette entry "Install App from AppStore") that:
1. Prompts the user for an app ID via `showInputBox`.
2. Calls the CLI as `wendy app install <app-id> [--device <addr>] [--no-start]` via the existing `DeviceManager` pattern (user-initiated, so analytics stays ON).
3. Shows progress and result notification.

Specifically:
- Add `installApp(appId, deviceAddress?, noStart?)` to `DeviceManager`.
- Register `wendy.installApp` in `extension.ts`.
- Add the command contribution to `package.json`.
