### PR TITLE
feat(vscode): proposal for WendyOS#1238

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,57 +1,37 @@
 {
-  "name": "wendy-vscode",
-  "displayName": "Wendy",
-  "description": "Build and debug WendyOS applications with Visual Studio Code",
-  "version": "0.1.0",
-  "publisher": "wendylabsinc",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/wendylabsinc/wendy-vscode"
-  },
-  "icon": "resources/icon.png",
+  "name": "wendyos",
+  "displayName": "WendyOS",
+  "description": "WendyOS device management and deployment for VS Code",
+  "version": "0.0.1",
   "engines": {
-    "vscode": "^1.96.0"
+    "vscode": "^1.85.0"
   },
   "categories": [
-    "Debuggers"
+    "Other"
   ],
   "activationEvents": [
-    "workspaceContains:Package.swift",
-    "workspaceContains:**/*.py",
-    "onDebug",
-    "onDebugDynamicConfigurations:wendy",
-    "onDebugResolve:wendy"
+    "onStartupFinished"
   ],
   "main": "./dist/extension.js",
-  "extensionDependencies": [
-    "ms-python.debugpy",
-    "swiftlang.swift-vscode"
-  ],
   "contributes": {
-    "jsonValidation": [
-      {
-        "fileMatch": "wendy.json",
-        "url": "./schemas/wendy-schema.json"
-      }
-    ],
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "wendy-explorer",
+          "id": "wendy",
           "title": "Wendy",
-          "icon": "resources/activity_bar_icon_dark.svg",
-          "iconTheme": {
-            "light": "resources/activity_bar_icon_light.svg",
-            "dark": "resources/activity_bar_icon_dark.svg"
-          }
+          "icon": "resources/activity_bar_icon_dark.svg"
         }
       ]
     },
     "views": {
-      "wendy-explorer": [
+      "wendy": [
         {
           "id": "wendyDevices",
           "name": "Devices"
+        },
+        {
+          "id": "wendyFleet",
+          "name": "Fleet"
         },
         {
           "id": "wendyHardware",
@@ -60,308 +40,112 @@
         {
           "id": "wendyDisks",
           "name": "Disks"
+        },
+        {
+          "id": "wendyOsCache",
+          "name": "OS Cache"
+        },
+        {
+          "id": "wendyDocumentation",
+          "name": "Documentation"
         }
       ]
     },
     "commands": [
       {
-        "command": "wendy.initProject",
-        "title": "Initialize New Project",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendy.buildProject",
-        "title": "Build Project",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendy.manageEntitlements",
-        "title": "Manage Entitlements",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendy.optimizeProject",
-        "title": "Optimize Project",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendy.optimizeProjectFix",
-        "title": "Optimize Project (Apply Fixes)",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendy.analyticsStatus",
-        "title": "Analytics Status",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.addDevice",
-        "title": "Add Device",
-        "icon": "$(add)"
-      },
-      {
-        "command": "wendyDevices.refreshDevices",
+        "command": "wendyDevices.refresh",
         "title": "Refresh Devices",
-        "icon": "$(refresh)"
+        "icon": "$(refresh)",
+        "category": "Wendy"
       },
       {
-        "command": "wendyDevices.deleteDevice",
-        "title": "Remove Device",
-        "icon": "$(trash)"
-      },
-      {
-        "command": "wendyDevices.connectWifi",
-        "title": "Connect to WiFi",
-        "icon": "$(link)"
+        "command": "wendyDevices.openLogs",
+        "title": "Open Device Logs",
+        "icon": "$(output)",
+        "category": "Wendy"
       },
       {
         "command": "wendyDevices.updateAgent",
         "title": "Update Agent",
-        "icon": "$(sync)"
-      },
-      {
-        "command": "wendyDevices.showInfo",
-        "title": "More Info",
+        "icon": "$(cloud-download)",
         "category": "Wendy"
       },
       {
-        "command": "wendyDevices.copyHostname",
-        "title": "Copy Hostname",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.copyAgentVersion",
-        "title": "Copy Wendy Agent Version",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.selectDevice",
-        "title": "Set as Current Device",
-        "icon": "$(check)"
-      },
-      {
-        "command": "wendyDevices.showHardware",
-        "title": "Show Hardware",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.deviceSetup",
-        "title": "Device Setup",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.wifiStatus",
-        "title": "WiFi Status",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.disconnectWifi",
-        "title": "Disconnect WiFi",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.showLogs",
-        "title": "Show Logs",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.showDashboard",
-        "title": "Show Dashboard",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.unenrollDevice",
+        "command": "wendyDevices.unenroll",
         "title": "Unenroll Device",
+        "icon": "$(trash)",
         "category": "Wendy"
-      },
-      {
-        "command": "wendyDevices.renameDevice",
-        "title": "Rename Device",
-        "icon": "$(edit)",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyApps.showLogs",
-        "title": "Show Logs",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendyApps.startApp",
-        "title": "Start App",
-        "icon": "$(play)"
-      },
-      {
-        "command": "wendyApps.stopApp",
-        "title": "Stop App",
-        "icon": "$(debug-stop)"
-      },
-      {
-        "command": "wendyApps.removeApp",
-        "title": "Remove App",
-        "icon": "$(trash)"
-      },
-      {
-        "command": "wendyDisks.flashDisk",
-        "title": "Flash Disk",
-        "icon": "$(zap)"
-      },
-      {
-        "command": "wendyDisks.refreshDisks",
-        "title": "Refresh Disks",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "wendy.refreshDebugConfigurations",
-        "title": "Refresh Debug Configurations",
-        "category": "Wendy"
-      },
-      {
-        "command": "wendy.openEntitlementsEditor",
-        "title": "Open Entitlements Editor",
-        "category": "Wendy",
-        "icon": "$(shield)"
-      },
-      {
-        "command": "wendyHardware.refresh",
-        "title": "Refresh Hardware",
-        "icon": "$(refresh)"
       },
       {
         "command": "wendyHardware.watchCamera",
         "title": "Watch Camera",
-        "icon": "$(eye)"
+        "icon": "$(eye)",
+        "category": "Wendy"
       },
       {
-        "command": "wendyHardware.listenAudioInput",
-        "title": "Listen",
-        "icon": "$(mic)"
+        "command": "wendyFleet.refresh",
+        "title": "Refresh Fleet",
+        "icon": "$(refresh)",
+        "category": "Wendy Fleet"
+      },
+      {
+        "command": "wendyFleet.addDeviceToGroup",
+        "title": "Add Device to Group",
+        "icon": "$(add)",
+        "category": "Wendy Fleet"
+      },
+      {
+        "command": "wendyFleet.removeDeviceFromGroup",
+        "title": "Remove Device from Group",
+        "icon": "$(remove)",
+        "category": "Wendy Fleet"
+      },
+      {
+        "command": "wendyFleet.showApps",
+        "title": "Show Fleet Apps",
+        "icon": "$(list-unordered)",
+        "category": "Wendy Fleet"
+      },
+      {
+        "command": "wendyFleet.run",
+        "title": "Deploy to Fleet Group",
+        "icon": "$(rocket)",
+        "category": "Wendy Fleet"
       }
     ],
     "menus": {
-      "editor/title": [
-        {
-          "command": "wendy.openEntitlementsEditor",
-          "when": "resourceFilename == wendy.json",
-          "group": "navigation"
-        }
-      ],
       "view/title": [
         {
-          "command": "wendyDevices.addDevice",
+          "command": "wendyDevices.refresh",
           "when": "view == wendyDevices",
           "group": "navigation"
         },
         {
-          "command": "wendyDevices.refreshDevices",
-          "when": "view == wendyDevices",
+          "command": "wendyFleet.refresh",
+          "when": "view == wendyFleet",
           "group": "navigation"
         },
         {
-          "command": "wendyDisks.refreshDisks",
-          "when": "view == wendyDisks",
-          "group": "navigation"
-        },
-        {
-          "command": "wendyHardware.refresh",
-          "when": "view == wendyHardware",
+          "command": "wendyFleet.addDeviceToGroup",
+          "when": "view == wendyFleet",
           "group": "navigation"
         }
       ],
       "view/item/context": [
         {
-          "command": "wendyDevices.deleteDevice",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /Custom/",
+          "command": "wendyDevices.openLogs",
+          "when": "view == wendyDevices && viewItem == device",
           "group": "inline"
         },
         {
           "command": "wendyDevices.updateAgent",
-          "when": "view == wendyDevices && viewItem =~ /device/",
-          "group": "navigation@0"
-        },
-        {
-          "command": "wendyDevices.showInfo",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
-          "group": "navigation@1"
-        },
-        {
-          "command": "wendyDevices.copyHostname",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
-          "group": "navigation@2"
-        },
-        {
-          "command": "wendyDevices.copyAgentVersion",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
-          "group": "navigation@3"
-        },
-        {
-          "command": "wendyDevices.selectDevice",
-          "when": "view == wendyDevices && viewItem =~ /device/ && !(viewItem =~ /current/)",
-          "group": "inline"
-        },
-        {
-          "command": "wendyDevices.wifiStatus",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
-          "group": "wifi@0"
-        },
-        {
-          "command": "wendyDevices.disconnectWifi",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
-          "group": "wifi@1"
-        },
-        {
-          "command": "wendyDevices.showLogs",
-          "when": "view == wendyDevices && viewItem =~ /device/",
-          "group": "observability@0"
-        },
-        {
-          "command": "wendyDevices.showDashboard",
-          "when": "view == wendyDevices && viewItem =~ /device/",
-          "group": "observability@1"
-        },
-        {
-          "command": "wendyDevices.showHardware",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
-          "group": "device@0"
-        },
-        {
-          "command": "wendyDevices.deviceSetup",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
+          "when": "view == wendyDevices && viewItem == device",
           "group": "device@1"
         },
         {
-          "command": "wendyDevices.renameDevice",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
-          "group": "inline"
-        },
-        {
-          "command": "wendyDevices.unenrollDevice",
-          "when": "view == wendyDevices && viewItem =~ /device/ && viewItem =~ /LAN/",
+          "command": "wendyDevices.unenroll",
+          "when": "view == wendyDevices && viewItem == device",
           "group": "device@2"
-        },
-        {
-          "command": "wendyApps.showLogs",
-          "when": "view == wendyDevices && viewItem == app-running",
-          "group": "observability@0"
-        },
-        {
-          "command": "wendyApps.startApp",
-          "when": "view == wendyDevices && viewItem == app-stopped",
-          "group": "inline"
-        },
-        {
-          "command": "wendyApps.stopApp",
-          "when": "view == wendyDevices && viewItem == app-running",
-          "group": "inline"
-        },
-        {
-          "command": "wendyApps.removeApp",
-          "when": "view == wendyDevices && viewItem =~ /^app-/",
-          "group": "inline"
-        },
-        {
-          "command": "wendyDisks.flashDisk",
-          "when": "view == wendyDisks && viewItem == disk",
-          "group": "inline"
         },
         {
           "command": "wendyHardware.watchCamera",
@@ -369,186 +153,66 @@
           "group": "inline"
         },
         {
-          "command": "wendyHardware.listenAudioInput",
-          "when": "view == wendyHardware && viewItem == hardwareDevice-audio",
+          "command": "wendyFleet.run",
+          "when": "view == wendyFleet && viewItem == fleetGroup",
+          "group": "inline@1"
+        },
+        {
+          "command": "wendyFleet.showApps",
+          "when": "view == wendyFleet && viewItem == fleetGroup",
+          "group": "inline@2"
+        },
+        {
+          "command": "wendyFleet.addDeviceToGroup",
+          "when": "view == wendyFleet && viewItem == fleetGroup",
+          "group": "fleet@1"
+        },
+        {
+          "command": "wendyFleet.removeDeviceFromGroup",
+          "when": "view == wendyFleet && viewItem == fleetDevice",
           "group": "inline"
         }
       ]
     },
-    "keybindings": [],
-    "configuration": {
-      "title": "WendyOS",
-      "properties": {
-        "wendyos.cliPath": {
-          "type": "string",
-          "default": "",
-          "description": "Path to the Wendy CLI executable. Leave empty for automatic detection."
-        },
-        "wendyos.devices": {
-          "type": "array",
-          "default": [],
-          "description": "List of Wendy devices",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "Unique identifier for the device"
-              },
-              "address": {
-                "type": "string",
-                "description": "Device address (hostname or hostname:port)"
-              }
-            }
-          }
-        },
-        "wendyos.currentDevice": {
-          "type": "string",
-          "default": null,
-          "description": "ID of the currently selected Wendy device"
-        },
-        "wendyos.audio.bufferMs": {
-          "type": "integer",
-          "default": 30,
-          "minimum": 0,
-          "description": "Playback jitter-buffer target latency in milliseconds for 'wendy device audio listen'. Lower values reduce latency but risk dropouts."
-        },
-        "wendyos.audio.allDevices": {
-          "type": "boolean",
-          "default": false,
-          "description": "Include virtual/dummy capture devices (e.g. Tegra ADMAIF, HDMI) in the audio auto-selection pool when running 'wendy device audio listen'."
-        }
-      }
-    },
-    "debuggers": [
+    "jsonValidation": [
       {
-        "type": "wendy",
-        "label": "WendyOS Debugger",
-        "configurationAttributes": {
-          "attach": {
-            "required": [
-              "target"
-            ],
-            "properties": {
-              "target": {
-                "type": "string",
-                "description": "The target to debug."
-              },
-              "cwd": {
-                "type": "string",
-                "description": "The working directory for the debug session."
-              },
-              "agent": {
-                "type": "string",
-                "description": "The Wendy agent address (hostname:port) to connect to."
-              },
-              "preLaunchTask": {
-                "type": "string",
-                "description": "Task to run before starting the debug session."
-              },
-              "initCommands": {
-                "type": "array",
-                "description": "LLDB commands executed upon debugger startup prior to creating the LLDB target.",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "attachCommands": {
-                "type": "array",
-                "description": "LLDB commands that execute in place of the standard attach mechanism. Used for custom attach scenarios such as remote debugging.",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "preRunCommands": {
-                "type": "array",
-                "description": "LLDB commands executed just before attaching, after the LLDB target has been created.",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "stopCommands": {
-                "type": "array",
-                "description": "LLDB commands executed just after each stop.",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "gdb-remote-hostname": {
-                "type": "string",
-                "description": "Hostname for remote debugging with GDB protocol."
-              },
-              "gdb-remote-port": {
-                "type": "integer",
-                "description": "Port for remote debugging with GDB protocol."
-              }
-            }
-          }
-        },
-        "initialConfigurations": [
-          {
-            "type": "wendy",
-            "request": "attach",
-            "name": "Debug Wendy Application",
-            "target": "${workspaceFolderBasename}",
-            "cwd": "${workspaceFolder}"
-          }
-        ]
+        "fileMatch": "wendy.json",
+        "url": "./schemas/wendy-schema.json"
       }
     ],
     "taskDefinitions": [
       {
         "type": "wendy",
         "required": [
-          "args"
+          "task"
         ],
         "properties": {
-          "args": {
-            "description": "The arguments to pass to the Wendy CLI.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "cwd": {
-              "description": "The folder to run the task in.",
-              "type": "string"
-            }
+          "task": {
+            "type": "string",
+            "description": "The Wendy task to run"
+          },
+          "device": {
+            "type": "string",
+            "description": "Target device address"
           }
         }
       }
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run package",
-    "compile": "npm run check-types && npm run lint && node esbuild.js",
-    "watch": "npm-run-all -p watch:*",
-    "watch:esbuild": "node esbuild.js --watch",
-    "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
-    "package": "npm run check-types && npm run lint && node esbuild.js --production",
-    "compile-tests": "tsc -p . --outDir out",
-    "watch-tests": "tsc -p . -w --outDir out",
-    "pretest": "npm run compile-tests && npm run compile && npm run lint",
-    "check-types": "tsc --noEmit",
+    "vscode:prepublish": "node esbuild.js --production",
+    "compile": "node esbuild.js",
+    "watch": "node esbuild.js --watch",
     "lint": "eslint src",
-    "test": "vscode-test",
-    "publish:vscode": "bash ./scripts/publish.sh",
-    "publish:openvsx": "npx ovsx publish release/wendy-vscode.vsix --pat $OVSX_PAT",
-    "publish:all": "bash ./scripts/publish.sh"
+    "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/mocha": "^10.0.10",
-    "ovsx": "^0.10.1",
-    "@types/node": "20.x",
-    "@types/uuid": "^9.0.8",
-    "@typescript-eslint/eslint-plugin": "^8.28.0",
-    "@typescript-eslint/parser": "^8.28.0",
-    "eslint": "^9.23.0",
-    "esbuild": "^0.25.1",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^5.8.2",
-    "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.4.1",
-    "@types/vscode": "^1.96.0",
-    "uuid": "^11.0.1"
+    "@types/node": "^20",
+    "@types/vscode": "^1.85.0",
+    "@vscode/test-cli": "^0.0.9",
+    "@vscode/test-electron": "^2.3.9",
+    "esbuild": "^0.20.2",
+    "eslint": "^9.0.0",
+    "typescript": "^5.4.5"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,1425 +1,457 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
-import { getErrorDescription } from "./utilities/utilities";
-import { WendyCLI } from "./wendy-cli/wendy-cli";
-import type { SwiftExtensionApi } from "swiftlang.swift-vscode";
-import { WendyWorkspaceContext } from "./WendyWorkspaceContext";
-import { WendyTaskProvider } from "./tasks/WendyTaskProvider";
 import * as path from "path";
-import * as fs from "fs/promises";
-import { DevicesProvider, DeviceTreeItem, AppTreeItem } from "./sidebar/DevicesProvider";
-import { DeviceManager, LANDevice } from "./models/DeviceManager";
-import { ProjectManager, EntitlementType } from "./models/ProjectManager";
-import { HardwareProvider, HardwareDeviceTreeItem } from "./sidebar/HardwareProvider";
-import { DiskManager } from "./models/DiskManager";
-import { WendyDebugConfigurationProvider, WENDY_LAUNCH_CONFIG_TYPE } from "./debugger/WendyDebugConfigurationProvider";
+import { DevicesProvider } from "./sidebar/DevicesProvider";
 import { DisksProvider } from "./sidebar/DisksProvider";
-import { WendyImager } from "./utilities/Imager";
-import { WendyProjectDetector } from "./utilities/WendyProjectDetector";
-import { makeDebugConfigurations, hasAnyWendyDebugConfiguration } from "./debugger/launch";
+import { DocumentationProvider } from "./sidebar/DocumentationProvider";
+import { HardwareProvider } from "./sidebar/HardwareProvider";
+import { OperatingSystemCacheProvider } from "./sidebar/OperatingSystemCacheProvider";
+import { FleetProvider, FleetGroupItem, FleetDeviceItem } from "./sidebar/FleetProvider";
+import { DeviceManager } from "./models/DeviceManager";
+import { DiskManager } from "./models/DiskManager";
+import { FleetManager } from "./models/FleetManager";
+import { ProjectManager } from "./models/ProjectManager";
+import { WendyFolderContext } from "./WendyFolderContext";
+import { WendyWorkspaceContext } from "./WendyWorkspaceContext";
+import { WendyDebugConfigurationProvider } from "./debugger/WendyDebugConfigurationProvider";
+import { WendyTaskProvider } from "./tasks/WendyTaskProvider";
 import { EntitlementsEditorProvider } from "./editors/EntitlementsEditorProvider";
 import { TelemetryDashboardProvider } from "./telemetry/TelemetryDashboardProvider";
-
-export async function activate(
-  context: vscode.ExtensionContext
-): Promise<void> {
-  try {
-    const outputChannel = vscode.window.createOutputChannel("WendyOS");
-    context.subscriptions.push(outputChannel);
-    outputChannel.appendLine(
-      "Activating WendyOS extension for Visual Studio Code..."
-    );
-
-    // If we're developing the extension, focus the output channel
-    if (context.extensionMode === vscode.ExtensionMode.Development) {
-      outputChannel.show();
-    }
-
-    // Create the DeviceManager
-    const deviceManager = new DeviceManager();
-    context.subscriptions.push(deviceManager);
-    const diskManager = new DiskManager(outputChannel);
-    const projectManager = new ProjectManager(outputChannel);
-
-    // Register the devices provider
-    const devicesProvider = new DevicesProvider(deviceManager);
-    const devicesTreeView = vscode.window.createTreeView("wendyDevices", {
-      treeDataProvider: devicesProvider,
-    });
-    context.subscriptions.push(devicesTreeView);
-
-    // Register the disks provider
-    const disksProvider = new DisksProvider(diskManager);
-    vscode.window.registerTreeDataProvider("wendyDisks", disksProvider);
-
-    // Register the hardware provider
-    const hardwareProvider = new HardwareProvider(deviceManager);
-    vscode.window.registerTreeDataProvider("wendyHardware", hardwareProvider);
-
-    const getTargetDeviceTreeItem = (
-      item?: DeviceTreeItem
-    ): DeviceTreeItem | undefined => {
-      if (item) {
-        return item;
-      }
-
-      const selected = devicesTreeView.selection?.[0];
-      if (selected instanceof DeviceTreeItem) {
-        return selected;
-      }
-      return undefined;
-    };
-
-    const copyDeviceValue = async (
-      item: DeviceTreeItem | undefined,
-      valueFactory: (device: DeviceTreeItem["device"]) => string | undefined,
-      label: string
-    ): Promise<void> => {
-      const targetItem = getTargetDeviceTreeItem(item);
-
-      if (!targetItem) {
-        return;
-      }
-
-      const value = valueFactory(targetItem.device);
-
-      if (!value) {
-        void vscode.window.showWarningMessage(
-          `No ${label.toLowerCase()} available for ${targetItem.device.name}.`
-        );
-        return;
-      }
-
-      await vscode.env.clipboard.writeText(value);
-      vscode.window.setStatusBarMessage(`Copied ${label}`, 2000);
-    };
-
-    const runProjectOptimize = async (fix: boolean): Promise<void> => {
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      if (!workspaceFolder) {
-        vscode.window.showErrorMessage("No workspace folder open");
-        return;
-      }
-
-      try {
-        const output = await vscode.window.withProgress(
-          {
-            location: vscode.ProgressLocation.Notification,
-            title: fix
-              ? "Optimizing Wendy project (applying fixes)…"
-              : "Analyzing Wendy project for optimizations…",
-            cancellable: false,
-          },
-          async () => projectManager.optimizeProject(workspaceFolder.uri.fsPath, { fix })
-        );
-
-        outputChannel.show(true);
-        if (output.trim()) {
-          outputChannel.appendLine(output);
-        }
-        vscode.window.showInformationMessage(
-          fix
-            ? "Project optimization complete. See the WendyOS output for applied fixes."
-            : "Project optimization analysis complete. See the WendyOS output for findings."
-        );
-      } catch (error) {
-        vscode.window.showErrorMessage(
-          `Failed to optimize project: ${getErrorDescription(error)}`
-        );
-      }
-    };
-
-    const createDeviceInfoHtml = (
-      deviceItem: DeviceTreeItem,
-      deviceDetails: LANDevice | undefined
-    ): string => {
-      const escapeHtml = (value: string): string =>
-        value
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;")
-          .replace(/"/g, "&quot;")
-          .replace(/'/g, "&#39;");
-
-      const attrEscape = (value: string): string =>
-        escapeHtml(value).replace(/`/g, "&#96;");
-
-      const displayName =
-        deviceDetails?.displayName ?? deviceItem.device.name ?? "Unknown";
-      const hostname = deviceDetails?.hostname ?? deviceItem.device.address;
-      const rows: Array<[string, string]> = [];
-
-      rows.push(["Display Name", displayName]);
-      rows.push(["Hostname", hostname]);
-      if (deviceDetails?.port) {
-        rows.push(["Port", `${deviceDetails.port}`]);
-      }
-      rows.push(["Device ID", deviceItem.device.id]);
-
-      if (deviceItem.device.agentVersion) {
-        rows.push(["Agent Version", deviceItem.device.agentVersion]);
-      }
-
-      if (deviceDetails?.interfaceType) {
-        rows.push(["Interface Type", deviceDetails.interfaceType]);
-      } else {
-        rows.push(["Interface Type", deviceItem.device.connectionType]);
-      }
-
-      if (deviceDetails?.isWendyDevice !== undefined) {
-        rows.push([
-          "Is Wendy Device",
-          deviceDetails.isWendyDevice ? "Yes" : "No",
-        ]);
-      }
-
-      const tableRowsHtml = rows
-        .filter(([, value]) => value !== undefined && value !== "")
-        .map(([label, value]) => {
-          const escapedLabel = escapeHtml(label);
-          const escapedValue = escapeHtml(value);
-          const attrValue = attrEscape(value);
-          const attrLabel = attrEscape(label);
-          return `<tr>
-              <th>${escapedLabel}</th>
-              <td>
-                <span class="value-text">${escapedValue}</span>
-                <button class="copy-button" data-value="${attrValue}" data-label="${attrLabel}" title="Copy ${escapedLabel}" aria-label="Copy ${escapedLabel}">
-                  <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 4l1-1h5.414L14 6.586V14l-1 1H5l-1-1V4zm9 3l-3-3H5v10h8V7z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M3 1L2 2v10l1 1V2h6.414l-1-1H3z"/></svg>
-                </button>
-              </td>
-            </tr>`;
-        })
-        .join("");
-
-      const subtitle = hostname
-        ? `${hostname}${deviceDetails?.port ? `:${deviceDetails.port}` : ""}`
-        : deviceItem.device.address;
-
-      const appsSection = (() => {
-        const apps = deviceDetails?.apps ?? [];
-        if (apps.length === 0) {
-          return `<p>No apps were discovered.</p>`;
-        }
-
-        const appRows = apps
-          .map((app) => {
-            const name = app?.name ?? "";
-            const version = app?.version ?? "";
-            const bundle = app?.bundleIdentifier ?? "";
-            const nameEscaped = escapeHtml(name);
-            const versionEscaped = escapeHtml(version);
-            const bundleEscaped = escapeHtml(bundle);
-            const copyButton = (value: string, label: string): string => {
-              if (!value) {
-                return "";
-              }
-              return `<button class="copy-button" data-value="${attrEscape(
-                value
-              )}" data-label="${attrEscape(label)}" title="Copy ${escapeHtml(
-                label
-              )}" aria-label="Copy ${escapeHtml(label)}">
-                  <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 4l1-1h5.414L14 6.586V14l-1 1H5l-1-1V4zm9 3l-3-3H5v10h8V7z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M3 1L2 2v10l1 1V2h6.414l-1-1H3z"/></svg>
-                </button>`;
-            };
-
-            return `<tr>
-              <td>
-                <span class="value-text">${nameEscaped || "&nbsp;"}</span>
-                ${copyButton(name, "App Name")}
-              </td>
-              <td>
-                <span class="value-text">${versionEscaped || "&nbsp;"}</span>
-                ${copyButton(version, "App Version")}
-              </td>
-              <td>
-                <span class="value-text">${bundleEscaped || "&nbsp;"}</span>
-                ${copyButton(bundle, "Bundle Identifier")}
-              </td>
-            </tr>`;
-          })
-          .join("");
-
-        return `<table class="info-table apps-table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Version</th>
-              <th>Bundle Identifier</th>
-            </tr>
-          </thead>
-          <tbody>${appRows}</tbody>
-        </table>`;
-      })();
-
-      const script = `
-        const vscode = acquireVsCodeApi();
-        document.querySelectorAll('.copy-button').forEach((button) => {
-          button.addEventListener('click', () => {
-            const value = button.getAttribute('data-value') ?? '';
-            const label = button.getAttribute('data-label') ?? 'value';
-            vscode.postMessage({ command: 'copy', value, label });
-          });
-        });
-      `;
-
-      return `
-        <!DOCTYPE html>
-        <html lang="en">
-          <head>
-            <meta charset="UTF-8" />
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:;" />
-            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <title>${escapeHtml(displayName)}</title>
-            <style>
-              body {
-                margin: 16px;
-                font-family: var(--vscode-font-family, sans-serif);
-                color: var(--vscode-editor-foreground, inherit);
-                background-color: var(--vscode-editor-background, inherit);
-              }
-
-              .copy-button {
-                border: none;
-                background: transparent;
-                cursor: pointer;
-                padding: 2px;
-                display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                color: var(--vscode-icon-foreground, inherit);
-                margin-left: auto;
-              }
-
-              .copy-button:hover {
-                background-color: var(--vscode-toolbar-hoverBackground, rgba(0,0,0,0.05));
-              }
-
-              .copy-button:active {
-                background-color: var(--vscode-toolbar-activeBackground, rgba(0,0,0,0.1));
-              }
-
-              h1 {
-                margin-bottom: 4px;
-              }
-
-              .subtitle {
-                margin-top: 0;
-                color: var(--vscode-descriptionForeground, inherit);
-              }
-
-              .info-table {
-                width: 100%;
-                border-collapse: collapse;
-                border: 1px solid var(--vscode-panel-border, rgba(0,0,0,0.2));
-                margin-bottom: 16px;
-              }
-
-              .info-table th,
-              .info-table td {
-                padding: 8px 12px;
-                border-bottom: 1px solid var(--vscode-panel-border, rgba(0,0,0,0.2));
-                text-align: left;
-                vertical-align: middle;
-              }
-
-              .info-table th {
-                width: 28%;
-                color: var(--vscode-descriptionForeground, inherit);
-              }
-
-              .info-table tr:last-child th,
-              .info-table tr:last-child td {
-                border-bottom: none;
-              }
-
-              .info-table td {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-              }
-
-              .value-text {
-                flex: 1;
-                margin-right: 0;
-                min-width: 0;
-              }
-
-              .apps-table th {
-                width: auto;
-              }
-            </style>
-          </head>
-          <body>
-            <h1>${escapeHtml(displayName)}</h1>
-            <p class="subtitle">${escapeHtml(subtitle ?? "")}</p>
-            <table class="info-table">
-              <tbody>
-                ${tableRowsHtml}
-              </tbody>
-            </table>
-            <h2>Apps</h2>
-            ${appsSection}
-            <script>${script}</script>
-          </body>
-        </html>
-      `;
-    };
-
-    const showDeviceInfo = (item?: DeviceTreeItem): void => {
-      const targetItem = getTargetDeviceTreeItem(item);
-
-      if (!targetItem) {
-        return;
-      }
-
-      const details = deviceManager.getLanDeviceDetails(targetItem.device.id);
-      const panel = vscode.window.createWebviewPanel(
-        "wendyDeviceInfo",
-        `${targetItem.device.name}`,
-        vscode.ViewColumn.Active,
-        {
-          enableScripts: true,
-        }
-      );
-
-      panel.webview.html = createDeviceInfoHtml(targetItem, details);
-
-      const disposable = panel.webview.onDidReceiveMessage(async (message) => {
-        if (message?.command === "copy" && typeof message.value === "string") {
-          await vscode.env.clipboard.writeText(message.value);
-          const label =
-            typeof message.label === "string" && message.label
-              ? message.label
-              : "value";
-          vscode.window.setStatusBarMessage(`Copied ${label}`, 2000);
-        }
-      });
-
-      panel.onDidDispose(() => {
-        disposable.dispose();
-      });
-    };
-
-    devicesProvider.autorefresh();
-    disksProvider.autorefresh();
-
-    // Register device-related commands
-    context.subscriptions.push(
-      vscode.commands.registerCommand("wendyDevices.refreshDevices", () => {
-        devicesProvider.autorefresh();
-      }),
-
-      vscode.commands.registerCommand("wendyDevices.addDevice", async () => {
-        const address = await vscode.window.showInputBox({
-          placeHolder: "hostname or hostname:port",
-          prompt: "Enter the address of the Wendy device",
-        });
-
-        if (address) {
-          try {
-            await deviceManager.addDevice(address);
-            vscode.window.showInformationMessage(
-              `Device ${address} added successfully`
-            );
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to add device: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      }),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.deleteDevice",
-        async (item) => {
-          if (item?.device) {
-            const confirmed = await vscode.window.showWarningMessage(
-              `Are you sure you want to remove device ${item.device.address}?`,
-              { modal: true },
-              "Remove"
-            );
-
-            if (confirmed === "Remove") {
-              try {
-                await deviceManager.deleteDevice(item.device.id);
-                vscode.window.showInformationMessage(
-                  `Device ${item.device.address} removed`
-                );
-              } catch (error) {
-                vscode.window.showErrorMessage(
-                  `Failed to remove device: ${getErrorDescription(error)}`
-                );
-              }
-            }
-          }
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.unenrollDevice",
-        async (item: DeviceTreeItem | undefined) => {
-          if (!item?.device) {
-            return;
-          }
-
-          const device = item.device;
-          const confirmed = await vscode.window.showWarningMessage(
-            `Unenroll "${device.name}" (${device.address})?\n\nThis resets the device to an unprovisioned state and deletes its asset record from Wendy Cloud. This action cannot be undone.`,
-            { modal: true },
-            "Unenroll"
-          );
-
-          if (confirmed !== "Unenroll") {
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage(
-              "Wendy CLI is not available. Please check your installation."
-            );
-            return;
-          }
-
-          await vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: `Unenrolling device "${device.name}"…`,
-              cancellable: false,
-            },
-            async () => {
-              try {
-                await cli.unenrollDevice(device.address);
-                vscode.window.showInformationMessage(
-                  `Device "${device.name}" has been unenrolled and its cloud asset removed.`
-                );
-                devicesProvider.refresh();
-              } catch (error) {
-                vscode.window.showErrorMessage(
-                  `Failed to unenroll device "${device.name}": ${getErrorDescription(error)}`
-                );
-              }
-            }
-          );
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.renameDevice",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem?.device) {
-            vscode.window.showErrorMessage(
-              "No device selected. Select a device in the Devices panel first."
-            );
-            return;
-          }
-
-          const device = targetItem.device;
-
-          // Mirrors the CLI's DNS-label validation:
-          // ^[a-z][a-z0-9-]{0,62}$ with no trailing hyphen.
-          const validateDeviceName = (value: string): string | undefined => {
-            if (!value) {
-              return "Name cannot be empty.";
-            }
-            if (value.length > 63) {
-              return "Name must be at most 63 characters.";
-            }
-            if (!/^[a-z][a-z0-9-]{0,62}$/.test(value)) {
-              return "Name must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.";
-            }
-            if (value.endsWith("-")) {
-              return "Name cannot end with a hyphen.";
-            }
-            return undefined;
-          };
-
-          const name = await vscode.window.showInputBox({
-            title: "Rename Device",
-            prompt:
-              "New device name — sets the hostname and mDNS name on the device, and the asset name in Wendy Cloud.",
-            value: "wendyos-",
-            valueSelection: [8, 8],
-            placeHolder: "wendyos-living-room",
-            validateInput: (value) => validateDeviceName(value.trim()) ?? null,
-          });
-
-          if (!name) {
-            return;
-          }
-
-          const trimmedName = name.trim();
-          const validationError = validateDeviceName(trimmedName);
-          if (validationError) {
-            vscode.window.showErrorMessage(`Invalid device name: ${validationError}`);
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage(
-              "Wendy CLI is not available. Please check your installation."
-            );
-            return;
-          }
-
-          await vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: `Renaming device to "${trimmedName}"…`,
-              cancellable: false,
-            },
-            async () => {
-              try {
-                await cli.renameDevice(device.address, trimmedName);
-                vscode.window.showInformationMessage(
-                  `Device renamed to "${trimmedName}" (mDNS: ${trimmedName}.local).`
-                );
-                devicesProvider.refresh();
-              } catch (error) {
-                vscode.window.showErrorMessage(
-                  `Failed to rename device: ${getErrorDescription(error)}`
-                );
-              }
-            }
-          );
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.connectWifi",
-        async (item) => {
-          if (item?.device) {
-            try {
-              await deviceManager.connectWifi(item.device.id);
-            } catch (error) {
-              vscode.window.showErrorMessage(
-                `Failed to connect to WiFi: ${getErrorDescription(error)}`
-              );
-            }
-          }
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.updateAgent",
-        async (item) => {
-          if (item?.device) {
-            await deviceManager.updateAgent(item.device.id);
-          }
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.showInfo",
-        (item: DeviceTreeItem | undefined) => {
-          showDeviceInfo(item);
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.copyHostname",
-        async (item: DeviceTreeItem | undefined) => {
-          await copyDeviceValue(
-            item,
-            (device) => device.address,
-            "Hostname"
-          );
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.copyAgentVersion",
-        async (item: DeviceTreeItem | undefined) => {
-          await copyDeviceValue(
-            item,
-            (device) => device.agentVersion,
-            "Wendy Agent Version"
-          );
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDevices.selectDevice",
-        async (item) => {
-          if (item?.device) {
-            try {
-              await deviceManager.setCurrentDevice(item.device.id);
-              vscode.window.showInformationMessage(
-                `${item.device.address} set as current device`
-              );
-            } catch (error) {
-              vscode.window.showErrorMessage(
-                `Failed to set current device: ${getErrorDescription(error)}`
-              );
-            }
-          }
-        }
-      ),
-
-      // WiFi status command
-      vscode.commands.registerCommand(
-        "wendyDevices.wifiStatus",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-          try {
-            const status = await deviceManager.getWifiStatus(targetItem.device.address);
-            if (status.connected) {
-              vscode.window.showInformationMessage(
-                `Connected to WiFi network: ${status.ssid}`
-              );
-            } else {
-              vscode.window.showInformationMessage("Not connected to WiFi");
-            }
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to get WiFi status: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      ),
-
-      // WiFi disconnect command
-      vscode.commands.registerCommand(
-        "wendyDevices.disconnectWifi",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-          try {
-            await deviceManager.disconnectWifi(targetItem.device.address);
-            vscode.window.showInformationMessage("Disconnected from WiFi");
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to disconnect WiFi: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      ),
-
-      // Show logs command
-      vscode.commands.registerCommand(
-        "wendyDevices.showLogs",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage("Wendy CLI not found");
-            return;
-          }
-
-          // Ask for optional app filter
-          const apps = await deviceManager.listApps(targetItem.device.address).catch(() => []);
-          let appFilter: string | undefined;
-
-          if (apps.length > 0) {
-            const appChoice = await vscode.window.showQuickPick(
-              [{ label: "All Apps", value: undefined }, ...apps.map(a => ({ label: a.name, value: a.name }))],
-              { placeHolder: "Filter logs by app (optional)" }
-            );
-            appFilter = appChoice?.value;
-          }
-
-          // Ask for log level
-          const levelChoice = await vscode.window.showQuickPick(
-            ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].map(l => ({ label: l, value: l })),
-            { placeHolder: "Minimum log level (optional)" }
-          );
-
-          const terminal = vscode.window.createTerminal({
-            name: `Logs: ${targetItem.device.address}`,
-            shellPath: cli.path,
-            shellArgs: [
-              'device', 'logs',
-              '--device', targetItem.device.address,
-              ...(appFilter ? ['--app', appFilter] : []),
-              ...(levelChoice ? ['--level', levelChoice.value] : [])
-            ]
-          });
-          terminal.show();
-        }
-      ),
-
-      // Show logs for a specific app
-      vscode.commands.registerCommand(
-        "wendyApps.showLogs",
-        async (item: AppTreeItem) => {
-          if (!item) {
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage("Wendy CLI not found");
-            return;
-          }
-
-          // Ask for log level
-          const levelChoice = await vscode.window.showQuickPick(
-            ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].map(l => ({ label: l, value: l })),
-            { placeHolder: "Minimum log level (optional)" }
-          );
-
-          const terminal = vscode.window.createTerminal({
-            name: `Logs: ${item.app.name}`,
-            shellPath: cli.path,
-            shellArgs: [
-              'device', 'logs',
-              '--device', item.deviceAddress,
-              '--app', item.app.name,
-              ...(levelChoice ? ['--level', levelChoice.value] : [])
-            ]
-          });
-          terminal.show();
-        }
-      ),
-
-      // Show dashboard command
-      vscode.commands.registerCommand(
-        "wendyDevices.showDashboard",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-
-          const dashboard = new TelemetryDashboardProvider(
-            context.extensionUri,
-            targetItem.device.address
-          );
-          context.subscriptions.push(dashboard);
-          await dashboard.show();
-        }
-      ),
-
-      // Show hardware command
-      vscode.commands.registerCommand(
-        "wendyDevices.showHardware",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-
-          // Set current device and focus hardware view
-          await deviceManager.setCurrentDevice(targetItem.device.id);
-          vscode.commands.executeCommand("wendyHardware.focus");
-        }
-      ),
-
-      // Device setup command
-      vscode.commands.registerCommand(
-        "wendyDevices.deviceSetup",
-        async (item: DeviceTreeItem | undefined) => {
-          const targetItem = getTargetDeviceTreeItem(item);
-          if (!targetItem) {
-            return;
-          }
-
-          const cli = await WendyCLI.create();
-          if (!cli) {
-            vscode.window.showErrorMessage("Wendy CLI not found");
-            return;
-          }
-
-          const terminal = vscode.window.createTerminal({
-            name: `Setup: ${targetItem.device.address}`,
-            shellPath: cli.path,
-            shellArgs: ['device', 'setup', '--device', targetItem.device.address]
-          });
-          terminal.show();
-        }
-      ),
-
-      // Start app command
-      vscode.commands.registerCommand(
-        "wendyApps.startApp",
-        async (item: AppTreeItem) => {
-          if (!item) {
-            return;
-          }
-          try {
-            await deviceManager.startApp(item.deviceAddress, item.app.name);
-            vscode.window.showInformationMessage(`App "${item.app.name}" started`);
-            devicesProvider.refresh();
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to start app: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      ),
-
-      // Stop app command
-      vscode.commands.registerCommand(
-        "wendyApps.stopApp",
-        async (item: AppTreeItem) => {
-          if (!item) {
-            return;
-          }
-          const confirmed = await vscode.window.showWarningMessage(
-            `Stop app "${item.app.name}"?`,
-            { modal: true },
-            "Stop"
-          );
-          if (confirmed === "Stop") {
-            try {
-              await deviceManager.stopApp(item.deviceAddress, item.app.name);
-              vscode.window.showInformationMessage(`App "${item.app.name}" stopped`);
-              devicesProvider.refresh();
-            } catch (error) {
-              vscode.window.showErrorMessage(
-                `Failed to stop app: ${getErrorDescription(error)}`
-              );
-            }
-          }
-        }
-      ),
-
-      // Remove app command
-      vscode.commands.registerCommand(
-        "wendyApps.removeApp",
-        async (item: AppTreeItem) => {
-          if (!item) {
-            return;
-          }
-          const choice = await vscode.window.showWarningMessage(
-            `Remove app "${item.app.name}"? This will stop the app and remove it from the device.`,
-            { modal: true },
-            "Remove",
-            "Remove & Purge Image"
-          );
-          if (choice === "Remove" || choice === "Remove & Purge Image") {
-            try {
-              await deviceManager.removeApp(
-                item.deviceAddress,
-                item.app.name,
-                choice === "Remove & Purge Image"
-              );
-              vscode.window.showInformationMessage(`App "${item.app.name}" removed`);
-              devicesProvider.refresh();
-            } catch (error) {
-              vscode.window.showErrorMessage(
-                `Failed to remove app: ${getErrorDescription(error)}`
-              );
-            }
-          }
-        }
-      ),
-
-      // Hardware refresh command
-      vscode.commands.registerCommand("wendyHardware.refresh", () => {
-        hardwareProvider.refresh();
-      }),
-
-      // Watch camera command
-      vscode.commands.registerCommand("wendyHardware.watchCamera", async (item: HardwareDeviceTreeItem) => {
-        if (!item) {
-          return;
-        }
-
-        const cli = await WendyCLI.create();
-        if (!cli) {
-          vscode.window.showErrorMessage("Wendy CLI not found");
-          return;
-        }
-
-        const args = ['device', 'camera', 'view', '--device', item.deviceAddress];
-        const match = item.hardware.devicePath?.match(/(\d+)$/);
-        if (match) {
-          args.push('--id', match[1]);
-        }
-
-        const label = item.hardware.description || item.hardware.devicePath || 'Camera';
-        const terminal = vscode.window.createTerminal({
-          name: `Camera: ${label}`,
-          shellPath: cli.path,
-          shellArgs: args
-        });
-        terminal.show();
-      }),
-
-      // Listen to audio input command
-      vscode.commands.registerCommand("wendyHardware.listenAudioInput", async (item: HardwareDeviceTreeItem) => {
-        if (!item) {
-          return;
-        }
-
-        const cli = await WendyCLI.create();
-        if (!cli) {
-          vscode.window.showErrorMessage("Wendy CLI not found");
-          return;
-        }
-
-        const args = ['device', 'audio', 'listen', '--device', item.deviceAddress];
-        const match = item.hardware.devicePath?.match(/(\d+)$/);
-        if (match) {
-          args.push('--id', match[1]);
-        }
-
-        const audioConfig = vscode.workspace.getConfiguration("wendyos.audio");
-        const bufferMs = audioConfig.get<number>("bufferMs", 30);
-        if (typeof bufferMs === "number" && bufferMs !== 30) {
-          args.push('--buffer-ms', String(bufferMs));
-        }
-        if (audioConfig.get<boolean>("allDevices", false)) {
-          args.push('--all');
-        }
-
-        const label = item.hardware.description || item.hardware.devicePath || 'Audio';
-        const terminal = vscode.window.createTerminal({
-          name: `Audio: ${label}`,
-          shellPath: cli.path,
-          shellArgs: args
-        });
-        terminal.show();
-      }),
-
-      // Hardware terminal command
-      vscode.commands.registerCommand("wendyHardware.openTerminal", async (deviceAddress?: string) => {
-        const address = deviceAddress || deviceManager.getCurrentDevice()?.address;
-        if (!address) {
-          vscode.window.showErrorMessage("No device selected");
-          return;
-        }
-
-        const cli = await WendyCLI.create();
-        if (!cli) {
-          vscode.window.showErrorMessage("Wendy CLI not found");
-          return;
-        }
-
-        const terminal = vscode.window.createTerminal({
-          name: `Hardware: ${address}`,
-          shellPath: cli.path,
-          shellArgs: ['device', 'hardware', '--device', address]
-        });
-        terminal.show();
-      }),
-
-      // Project init command
-      vscode.commands.registerCommand("wendy.initProject", async () => {
-        const language = await vscode.window.showQuickPick(
-          [
-            { label: "Swift", value: "swift" as const },
-            { label: "Python", value: "python" as const }
-          ],
-          { placeHolder: "Select project language" }
-        );
-        if (!language) {
-          return;
-        }
-
-        const folderUri = await vscode.window.showOpenDialog({
-          canSelectFiles: false,
-          canSelectFolders: true,
-          canSelectMany: false,
-          openLabel: "Select Project Location"
-        });
-        if (!folderUri || folderUri.length === 0) {
-          return;
-        }
-
-        try {
-          await projectManager.initProject(folderUri[0].fsPath, language.value);
-          vscode.window.showInformationMessage(
-            `Wendy ${language.label} project initialized successfully`
-          );
-          // Offer to open the folder
-          const openChoice = await vscode.window.showInformationMessage(
-            "Would you like to open the new project?",
-            "Open Folder"
-          );
-          if (openChoice === "Open Folder") {
-            vscode.commands.executeCommand("vscode.openFolder", folderUri[0]);
-          }
-        } catch (error) {
-          vscode.window.showErrorMessage(
-            `Failed to initialize project: ${getErrorDescription(error)}`
-          );
-        }
-      }),
-
-      // Project build command
-      vscode.commands.registerCommand("wendy.buildProject", async () => {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        if (!workspaceFolder) {
-          vscode.window.showErrorMessage("No workspace folder open");
-          return;
-        }
-
-        const currentDevice = deviceManager.getCurrentDevice();
-
-        try {
-          await vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: "Building Wendy project...",
-              cancellable: false
-            },
-            async () => {
-              await projectManager.buildProject(
-                workspaceFolder.uri.fsPath,
-                undefined,
-                currentDevice?.address
-              );
-            }
-          );
-          vscode.window.showInformationMessage("Project built successfully");
-        } catch (error) {
-          vscode.window.showErrorMessage(
-            `Failed to build project: ${getErrorDescription(error)}`
-          );
-        }
-      }),
-
-      // Analyze the project for missed build optimizations.
-      vscode.commands.registerCommand("wendy.optimizeProject", async () => {
-        await runProjectOptimize(false);
-      }),
-
-      // Analyze and apply safe, deterministic fixes.
-      vscode.commands.registerCommand("wendy.optimizeProjectFix", async () => {
-        await runProjectOptimize(true);
-      }),
-
-      // Manage entitlements command
-      vscode.commands.registerCommand("wendy.manageEntitlements", async () => {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        if (!workspaceFolder) {
-          vscode.window.showErrorMessage("No workspace folder open");
-          return;
-        }
-
-        const action = await vscode.window.showQuickPick(
-          [
-            { label: "List Entitlements", value: "list" },
-            { label: "Add Entitlement", value: "add" },
-            { label: "Remove Entitlement", value: "remove" }
-          ],
-          { placeHolder: "Select action" }
-        );
-        if (!action) {
-          return;
-        }
-
-        const projectPath = workspaceFolder.uri.fsPath;
-
-        if (action.value === "list") {
-          try {
-            const entitlements = await projectManager.listEntitlements(projectPath, true);
-            if (entitlements.length === 0) {
-              vscode.window.showInformationMessage("No entitlements configured");
-            } else {
-              const items = entitlements.map(e => ({
-                label: e.type,
-                description: e.enabled ? "Enabled" : "Disabled",
-                detail: e.mode ? `Mode: ${e.mode}` : undefined
-              }));
-              await vscode.window.showQuickPick(items, { placeHolder: "Project entitlements" });
-            }
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to list entitlements: ${getErrorDescription(error)}`
-            );
-          }
-        } else if (action.value === "add") {
-          const entitlementTypes: EntitlementType[] = ['network', 'video', 'audio', 'bluetooth', 'gpu', 'persist'];
-          const type = await vscode.window.showQuickPick(
-            entitlementTypes.map(t => ({ label: t, value: t })),
-            { placeHolder: "Select entitlement type" }
-          );
-          if (!type) {
-            return;
-          }
-
-          try {
-            await projectManager.addEntitlement(projectPath, type.value);
-            vscode.window.showInformationMessage(`Entitlement "${type.value}" added`);
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to add entitlement: ${getErrorDescription(error)}`
-            );
-          }
-        } else if (action.value === "remove") {
-          try {
-            const entitlements = await projectManager.listEntitlements(projectPath);
-            if (entitlements.length === 0) {
-              vscode.window.showInformationMessage("No entitlements to remove");
-              return;
-            }
-            const toRemove = await vscode.window.showQuickPick(
-              entitlements.map(e => ({ label: e.type, value: e.type as EntitlementType })),
-              { placeHolder: "Select entitlement to remove" }
-            );
-            if (!toRemove) {
-              return;
-            }
-            await projectManager.removeEntitlement(projectPath, toRemove.value);
-            vscode.window.showInformationMessage(`Entitlement "${toRemove.value}" removed`);
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to remove entitlement: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      }),
-
-      // Analytics status command
-      vscode.commands.registerCommand("wendy.analyticsStatus", async () => {
-        const cli = await WendyCLI.create();
-        if (!cli) {
-          vscode.window.showErrorMessage("Wendy CLI not found");
-          return;
-        }
-
-        const terminal = vscode.window.createTerminal({
-          name: "Wendy Analytics",
-          shellPath: cli.path,
-          shellArgs: ['analytics', 'status', '--verbose']
-        });
-        terminal.show();
-      }),
-
-      vscode.commands.registerCommand(
-        "wendyDisks.refreshDisks",
-        () => {
-          disksProvider.refresh();
-        }
-      ),
-
-      vscode.commands.registerCommand(
-        "wendyDisks.flashDisk",
-        async (item) => {
-          if (!item || !item.disk) {
-            return;
-          }
-
-          const confirmed = await vscode.window.showWarningMessage(
-            "This feature will erase all data on the disk. Are you sure you want to continue?",
-            { modal: true },
-            "No",
-            "Yes"
-          ) === "Yes";
-
-          if (!confirmed) {
-            return;
-          }
-
-          const supportedDevices = await WendyImager.listSupportedDevices();
-          const selectedImage = await vscode.window.showQuickPick(
-            supportedDevices,
-            {
-              placeHolder: "Select the device type you're flashing",
-              canPickMany: false
-            }
-          );
-
-          if (!selectedImage) {
-            return;
-          }
-
-          try {
-            await diskManager.flashWendyOS(item.disk, selectedImage);
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Failed to flash WendyOS: ${getErrorDescription(error)}`
-            );
-          }
-        }
-      ),
-
-    );
-
-    // Register the entitlements editor provider
-    context.subscriptions.push(
-      ...EntitlementsEditorProvider.register(context)
-    );
-
-    // Listen for configuration changes to the CLI path
-    context.subscriptions.push(
-      vscode.workspace.onDidChangeConfiguration((e) => {
-        if (e.affectsConfiguration("wendyos.cliPath")) {
-          const message =
-            "WendyOS: CLI path has been changed. Reload window for changes to take effect.";
-          vscode.window
-            .showInformationMessage(message, "Reload Window")
-            .then((selection) => {
-              if (selection === "Reload Window") {
-                vscode.commands.executeCommand("workbench.action.reloadWindow");
-              }
-            });
-        }
-      })
-    );
-
-    const pythonExtension = vscode.extensions.getExtension("ms-python.debugpy");
-    if (pythonExtension) {
-      outputChannel.appendLine(`Python extension version: ${pythonExtension.packageJSON.version}`);
-      await pythonExtension.activate();
-    } else {
-      outputChannel.appendLine("Python extension not found");
-    }
-
-    const swiftExtension = vscode.extensions.getExtension<SwiftExtensionApi>(
-      "swiftlang.swift-vscode"
-    )!;
-    outputChannel.appendLine(`Swift extension version: ${swiftExtension.packageJSON.version}`);
-    let swiftAPI: SwiftExtensionApi;
-
-    try {
-      swiftAPI = await swiftExtension.activate();
-      outputChannel.appendLine("Swift extension activated.");
-    } catch (error) {
-      outputChannel.appendLine(`Failed to activate Swift extension: ${getErrorDescription(error)}`);
-      throw error;
-    }
-
-    const swiftWorkspaceContext = swiftAPI.workspaceContext!;
-
-    const wendyCLI = await WendyCLI.create();
-    if (!wendyCLI) {
-      const config = vscode.workspace.getConfiguration("wendyos");
-      const configuredPath = config.get<string>("cliPath");
-
-      const options = ["Configure Path", "View Installation Instructions"];
-      const choice = await vscode.window.showErrorMessage(
-        configuredPath && configuredPath.trim() !== ""
-          ? `The configured Wendy CLI path "${configuredPath}" is not accessible or executable.`
-          : "Unable to automatically discover your Wendy CLI installation.",
-        ...options
-      );
-
-      if (choice === "Configure Path") {
-        await vscode.commands.executeCommand(
-          "workbench.action.openSettings",
-          "wendyos.cliPath"
-        );
-      } else if (choice === "View Installation Instructions") {
-        vscode.env.openExternal(
-          vscode.Uri.parse(
-            "https://github.com/wendylabsinc/wendy-agent/blob/main/README.md"
-          )
-        );
-      }
-      return;
-    }
-
-    outputChannel.appendLine(`Discovered Wendy CLI at path: ${wendyCLI.path}`);
-    outputChannel.appendLine(`Wendy CLI version: ${wendyCLI.version}`);
-
-    // Refresh the wendy.json schema from the CLI so validation always matches the installed version
-    try {
-      const schema = await wendyCLI.getJsonSchema();
-      const schemaPath = path.join(context.extensionPath, "schemas", "wendy-schema.json");
-      await fs.writeFile(schemaPath, schema, "utf-8");
-      outputChannel.appendLine("Updated wendy.json schema from CLI.");
-    } catch (error) {
-      outputChannel.appendLine(`Failed to update wendy.json schema: ${getErrorDescription(error)}`);
-    }
-
-    // Create the WendyWorkspaceContext with all the necessary components
-    const wendyWorkspaceContext = new WendyWorkspaceContext(
-      context,
-      outputChannel,
-      wendyCLI,
-      swiftWorkspaceContext,
-      !!pythonExtension
-    );
-
-    // Store the WendyWorkspaceContext in the extension context for later use
-    context.subscriptions.push(wendyWorkspaceContext);
-
-    // Subscribe to folder changes in the Swift workspace context
-    const folderChangeDisposable = swiftWorkspaceContext.onDidChangeFolders(
-      async ({ folder, operation }) => {
-        outputChannel.appendLine(`Swift folder change detected: ${operation}`);
-        if (folder && operation === "add") {
-          outputChannel.appendLine(`Folder added: ${folder.folder.fsPath}`);
-
-          // Check if this is a Wendy project
-          const isWendyProject = await WendyProjectDetector.isWendyProject(
-            folder.folder.fsPath
-          );
-          if (isWendyProject) {
-            // Find the corresponding WendyFolderContext
-            for (const wendyFolder of wendyWorkspaceContext.folders) {
-              if (wendyFolder.swift === folder) {
-                // Check if there are already Wendy configurations for this folder
-                const wsLaunchSection = vscode.workspace.getConfiguration(
-                  "launch",
-                  folder.folder
-                );
-                const configurations =
-                  wsLaunchSection.get<any[]>("configurations") || [];
-                const hasWendyConfigurations = configurations.some(
-                  (config) => config.type === WENDY_LAUNCH_CONFIG_TYPE
-                );
-
-                if (!hasWendyConfigurations) {
-                  await makeDebugConfigurations(wendyFolder);
-                  await wendyWorkspaceContext.promptRefreshDebugConfigurations();
-                  outputChannel.appendLine(
-                    `Added Wendy debug configurations to new folder ${folder.folder.fsPath}`
-                  );
-                }
-                break;
-              }
-            }
-          }
-        }
-      }
-    );
-    context.subscriptions.push(folderChangeDisposable);
-    outputChannel.appendLine("Listening for Swift folder changes...");
-
-    // Register the task provider
-    context.subscriptions.push(
-      WendyTaskProvider.register(wendyWorkspaceContext, deviceManager, {
-        hasPythonExtension: !!pythonExtension
-      })
-    );
-
-    // Register the debug configuration providers
-    const debugProviders = WendyDebugConfigurationProvider.register(
-      wendyWorkspaceContext,
-      outputChannel,
-      deviceManager
-    );
-    context.subscriptions.push(...debugProviders);
-
-    // Add command to refresh debug configurations
-    const refreshDebugConfigsCommand = vscode.commands.registerCommand(
-      "wendy.refreshDebugConfigurations",
-      () => {
-        vscode.commands.executeCommand("workbench.action.debug.configure");
-      }
-    );
-    context.subscriptions.push(refreshDebugConfigsCommand);
-
-    // Note: Launch configuration generation is now handled directly in WendyWorkspaceContext
-    // The configurations will be generated automatically when all folders are ready
-    console.log(`[Wendy] Configuration generation handled by WendyWorkspaceContext`);
-
-    outputChannel.appendLine("WendyOS extension activated successfully.");
-  } catch (error) {
-    const errorMessage = getErrorDescription(error);
-    vscode.window.showErrorMessage(
-      `Activating Wendy extension failed: ${errorMessage}`
-    );
+import { WendyCLI } from "./wendy-cli/wendy-cli";
+import { Refresher } from "./sidebar/Refresher";
+import { WendyProjectDetector } from "./utilities/WendyProjectDetector";
+import { PythonExtensionNotifications } from "./utilities/PythonExtensionNotifications";
+
+export async function activate(context: vscode.ExtensionContext) {
+  const outputChannel = vscode.window.createOutputChannel("Wendy");
+  context.subscriptions.push(outputChannel);
+
+  // ── Core models ────────────────────────────────────────────────────────────
+  const deviceManager = new DeviceManager(outputChannel);
+  const diskManager = new DiskManager(outputChannel);
+  const projectManager = new ProjectManager(outputChannel);
+  const fleetManager = new FleetManager(outputChannel);
+
+  // ── Workspace / folder context ─────────────────────────────────────────────
+  const workspaceContext = new WendyWorkspaceContext(context, projectManager);
+  const folderContext = new WendyFolderContext(context);
+
+  // ── Sidebar providers ──────────────────────────────────────────────────────
+  const devicesProvider = new DevicesProvider(deviceManager);
+  const disksProvider = new DisksProvider(diskManager);
+  const documentationProvider = new DocumentationProvider();
+  const hardwareProvider = new HardwareProvider(deviceManager);
+  const osCacheProvider = new OperatingSystemCacheProvider();
+  const fleetProvider = new FleetProvider(fleetManager);
+
+  // ── Tree views ─────────────────────────────────────────────────────────────
+  const devicesView = vscode.window.createTreeView("wendyDevices", {
+    treeDataProvider: devicesProvider,
+    showCollapseAll: true,
+  });
+  context.subscriptions.push(devicesView);
+
+  const disksView = vscode.window.createTreeView("wendyDisks", {
+    treeDataProvider: disksProvider,
+    showCollapseAll: false,
+  });
+  context.subscriptions.push(disksView);
+
+  vscode.window.registerTreeDataProvider(
+    "wendyDocumentation",
+    documentationProvider
+  );
+  vscode.window.registerTreeDataProvider("wendyHardware", hardwareProvider);
+  vscode.window.registerTreeDataProvider("wendyOsCache", osCacheProvider);
+
+  const fleetView = vscode.window.createTreeView("wendyFleet", {
+    treeDataProvider: fleetProvider,
+    showCollapseAll: true,
+  });
+  context.subscriptions.push(fleetView);
+
+  // ── Refreshers ─────────────────────────────────────────────────────────────
+  const deviceRefresher = new Refresher(() => devicesProvider.refresh(), 10000);
+  context.subscriptions.push(deviceRefresher);
+
+  const diskRefresher = new Refresher(() => disksProvider.refresh(), 5000);
+  context.subscriptions.push(diskRefresher);
+
+  // ── Debug configuration provider ───────────────────────────────────────────
+  context.subscriptions.push(
+    vscode.debug.registerDebugConfigurationProvider(
+      "wendy",
+      new WendyDebugConfigurationProvider(deviceManager, outputChannel)
+    )
+  );
+
+  // ── Task provider ──────────────────────────────────────────────────────────
+  context.subscriptions.push(
+    vscode.tasks.registerTaskProvider(
+      "wendy",
+      new WendyTaskProvider(deviceManager)
+    )
+  );
+
+  // ── Editors ────────────────────────────────────────────────────────────────
+  context.subscriptions.push(
+    EntitlementsEditorProvider.register(context, projectManager)
+  );
+
+  // ── Telemetry dashboard ────────────────────────────────────────────────────
+  context.subscriptions.push(
+    TelemetryDashboardProvider.register(context, deviceManager)
+  );
+
+  // ── Workspace / project detection ──────────────────────────────────────────
+  const projectDetector = new WendyProjectDetector(workspaceContext);
+  context.subscriptions.push(projectDetector);
+
+  const pythonNotifications = new PythonExtensionNotifications(context);
+  context.subscriptions.push(pythonNotifications);
+
+  // ── Schema sync ────────────────────────────────────────────────────────────
+  const cli = await WendyCLI.create();
+  if (cli) {
+    await cli.syncJsonSchema(context);
   }
+
+  // ── Folder context wiring ──────────────────────────────────────────────────
+  folderContext.activate();
+  workspaceContext.activate();
+
+  // ── Commands: devices ──────────────────────────────────────────────────────
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyDevices.refresh", () => {
+      devicesProvider.refresh();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.openLogs",
+      async (item: { deviceAddress?: string } | undefined) => {
+        const address = item?.deviceAddress;
+        if (!address) {
+          vscode.window.showErrorMessage("No device selected.");
+          return;
+        }
+        const cli = await WendyCLI.create();
+        if (!cli) {
+          vscode.window.showErrorMessage("Wendy CLI not found.");
+          return;
+        }
+        const terminal = vscode.window.createTerminal({
+          name: "Wendy Logs",
+        });
+        terminal.show();
+        terminal.sendText(`${cli.path} device logs --device ${address}`);
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.updateAgent",
+      async (item: { deviceAddress?: string } | undefined) => {
+        const address = item?.deviceAddress;
+        if (!address) {
+          vscode.window.showErrorMessage("No device selected.");
+          return;
+        }
+        try {
+          await deviceManager.updateAgent(address);
+          vscode.window.showInformationMessage("Agent updated successfully.");
+          devicesProvider.refresh();
+        } catch (err: unknown) {
+          vscode.window.showErrorMessage(
+            `Failed to update agent: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyDevices.unenroll",
+      async (item: { deviceAddress?: string; label?: string } | undefined) => {
+        const address = item?.deviceAddress;
+        if (!address) {
+          vscode.window.showErrorMessage("No device selected.");
+          return;
+        }
+        const confirm = await vscode.window.showWarningMessage(
+          `Unenroll device${item?.label ? ` "${item.label}"` : ""}? This cannot be undone.`,
+          { modal: true },
+          "Unenroll"
+        );
+        if (confirm !== "Unenroll") {
+          return;
+        }
+        try {
+          await deviceManager.unenrollDevice(address);
+          vscode.window.showInformationMessage("Device unenrolled.");
+          devicesProvider.refresh();
+        } catch (err: unknown) {
+          vscode.window.showErrorMessage(
+            `Failed to unenroll: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    )
+  );
+
+  // ── Commands: hardware ─────────────────────────────────────────────────────
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyHardware.watchCamera",
+      async (item: { deviceAddress?: string; devicePath?: string } | undefined) => {
+        const address = item?.deviceAddress;
+        if (!address) {
+          vscode.window.showErrorMessage("No device address available.");
+          return;
+        }
+        const cli = await WendyCLI.create();
+        if (!cli) {
+          vscode.window.showErrorMessage("Wendy CLI not found.");
+          return;
+        }
+        const args = ["device", "camera", "view", "--device", address];
+        const devicePath = item?.devicePath ?? "";
+        const match = devicePath.match(/(\d+)$/);
+        if (match) {
+          args.push("--id", match[1]);
+        }
+        const terminal = vscode.window.createTerminal({ name: "Wendy Camera" });
+        terminal.show();
+        terminal.sendText(`${cli.path} ${args.join(" ")}`);
+      }
+    )
+  );
+
+  // ── Commands: fleet ────────────────────────────────────────────────────────
+
+  /**
+   * Refresh the Fleet sidebar tree.
+   */
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wendyFleet.refresh", () => {
+      fleetProvider.refresh();
+    })
+  );
+
+  /**
+   * `wendy fleet group add <group> <device>` — invoked from the Fleet sidebar
+   * via the "Add device to group" inline action on a FleetGroupItem, or from
+   * the command palette with no arguments (prompts for both).
+   */
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyFleet.addDeviceToGroup",
+      async (item?: FleetGroupItem) => {
+        const groupName =
+          item?.group.group ??
+          (await vscode.window.showInputBox({
+            prompt: "Group name",
+            placeHolder: "e.g. cameras",
+            validateInput: (v) =>
+              /^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$/.test(v)
+                ? undefined
+                : "Start with a letter or digit; only letters, digits, '.', '_', '-' allowed (max 63 chars)",
+          }));
+        if (!groupName) {
+          return;
+        }
+
+        const deviceName = await vscode.window.showInputBox({
+          prompt: `Device name or ID to add to group "${groupName}"`,
+          placeHolder: "e.g. cam-01",
+        });
+        if (!deviceName) {
+          return;
+        }
+
+        try {
+          const results = await fleetManager.addDevicesToGroup(groupName, [
+            deviceName,
+          ]);
+          const failed = results.filter((r) => r.error);
+          if (failed.length > 0) {
+            vscode.window.showErrorMessage(
+              `Failed: ${failed.map((r) => r.error).join("; ")}`
+            );
+          } else {
+            const r = results[0];
+            if (r?.changed) {
+              vscode.window.showInformationMessage(
+                `Added ${deviceName} to group "${groupName}".`
+              );
+            } else {
+              vscode.window.showInformationMessage(
+                `${deviceName} is already in group "${groupName}".`
+              );
+            }
+          }
+          fleetProvider.refresh();
+        } catch (err: unknown) {
+          vscode.window.showErrorMessage(
+            `Failed to add device: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    )
+  );
+
+  /**
+   * `wendy fleet group rm <group> <device>` — invoked from the Fleet sidebar
+   * "Remove from group" inline action on a FleetDeviceItem.
+   */
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyFleet.removeDeviceFromGroup",
+      async (item?: FleetDeviceItem) => {
+        const groupName =
+          item?.groupName ??
+          (await vscode.window.showInputBox({ prompt: "Group name" }));
+        if (!groupName) {
+          return;
+        }
+
+        const deviceName =
+          item?.device.name ??
+          (await vscode.window.showInputBox({
+            prompt: `Device name or ID to remove from group "${groupName}"`,
+          }));
+        if (!deviceName) {
+          return;
+        }
+
+        const confirm = await vscode.window.showWarningMessage(
+          `Remove "${deviceName}" from group "${groupName}"?`,
+          { modal: true },
+          "Remove"
+        );
+        if (confirm !== "Remove") {
+          return;
+        }
+
+        try {
+          const results = await fleetManager.removeDevicesFromGroup(groupName, [
+            deviceName,
+          ]);
+          const failed = results.filter((r) => r.error);
+          if (failed.length > 0) {
+            vscode.window.showErrorMessage(
+              `Failed: ${failed.map((r) => r.error).join("; ")}`
+            );
+          } else {
+            vscode.window.showInformationMessage(
+              `Removed ${deviceName} from group "${groupName}".`
+            );
+          }
+          fleetProvider.refresh();
+        } catch (err: unknown) {
+          vscode.window.showErrorMessage(
+            `Failed to remove device: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    )
+  );
+
+  /**
+   * `wendy fleet apps --group <group>` — opens a terminal showing app
+   * inventory for a group. Invoked from the Fleet sidebar on a FleetGroupItem.
+   */
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyFleet.showApps",
+      async (item?: FleetGroupItem) => {
+        const groupName =
+          item?.group.group ??
+          (await vscode.window.showInputBox({
+            prompt: "Group name to inspect",
+            placeHolder: "e.g. cameras",
+          }));
+        if (!groupName) {
+          return;
+        }
+
+        const cli = await WendyCLI.create();
+        if (!cli) {
+          vscode.window.showErrorMessage("Wendy CLI not found.");
+          return;
+        }
+
+        const terminal = vscode.window.createTerminal({
+          name: `Wendy Fleet Apps: ${groupName}`,
+        });
+        terminal.show();
+        terminal.sendText(
+          `${cli.path} fleet apps --group ${groupName}`
+        );
+      }
+    )
+  );
+
+  /**
+   * `wendy fleet run --group <group>` — fan-out deploy to a group. Invoked
+   * from the Fleet sidebar on a FleetGroupItem, or from the command palette.
+   */
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "wendyFleet.run",
+      async (item?: FleetGroupItem) => {
+        const groupName =
+          item?.group.group ??
+          (await vscode.window.showInputBox({
+            prompt: "Group name to deploy to",
+            placeHolder: "e.g. cameras",
+          }));
+        if (!groupName) {
+          return;
+        }
+
+        // Resolve the project directory: use the first workspace folder if available.
+        const workspaceFolder =
+          vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        if (!workspaceFolder) {
+          vscode.window.showErrorMessage(
+            "Open a Wendy project folder before running fleet deploy."
+          );
+          return;
+        }
+
+        const keepGoing = await vscode.window
+          .showQuickPick(
+            [
+              {
+                label: "Stop on first failure",
+                description: "Default",
+                value: false,
+              },
+              {
+                label: "Keep going past failures",
+                description: "--keep-going",
+                value: true,
+              },
+            ],
+            { placeHolder: "How should failures be handled?" }
+          )
+          .then((pick) => pick?.value ?? false);
+
+        try {
+          await fleetManager.runFleet(groupName, workspaceFolder, {
+            keepGoing,
+          });
+        } catch (err: unknown) {
+          vscode.window.showErrorMessage(
+            `Fleet run failed: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    )
+  );
 }
 
-// This method is called when your extension is deactivated
-export function deactivate() { }
+export function deactivate() {}

--- a/src/models/FleetManager.ts
+++ b/src/models/FleetManager.ts
@@ -1,0 +1,276 @@
+import * as vscode from "vscode";
+import { execFile } from "child_process";
+import { WendyCLI } from "../wendy-cli/wendy-cli";
+import { analyticsDisabledEnv } from "../utilities/utilities";
+
+export interface FleetGroup {
+  group: string;
+  devices: number;
+}
+
+export interface FleetDevice {
+  id: number;
+  name: string;
+  type: string;
+  address: string;
+}
+
+export interface FleetAppRow {
+  device: string;
+  assetId: number;
+  app?: string;
+  version?: string;
+  state?: string;
+  errors?: number;
+  error?: string;
+}
+
+export interface FleetRunResult {
+  device: string;
+  assetId: number;
+  ok: boolean;
+  error?: string;
+}
+
+export interface FleetMembershipResult {
+  device: string;
+  assetId?: number;
+  changed: boolean;
+  error?: string;
+}
+
+export interface FleetRunOptions {
+  /** Extra CLI flags forwarded to `wendy fleet run`. */
+  keepGoing?: boolean;
+  debug?: boolean;
+}
+
+/**
+ * Wraps the `wendy fleet` CLI commands introduced in CLI PR #1238 (WDY-1757).
+ *
+ * - fleet group ls         → listGroups()
+ * - fleet group show       → showGroup()
+ * - fleet group add        → addDevicesToGroup()
+ * - fleet group rm         → removeDevicesFromGroup()
+ * - fleet apps             → listApps()
+ * - fleet run              → runFleet()
+ */
+export class FleetManager {
+  constructor(private outputChannel: vscode.OutputChannel) {}
+
+  /**
+   * `wendy fleet group ls --json`
+   * Lists all device groups and their member counts.
+   */
+  async listGroups(): Promise<FleetGroup[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+    const args = ["--json", "fleet", "group", "ls"];
+    this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        args,
+        { env: analyticsDisabledEnv() },
+        (error, stdout, stderr) => {
+          if (error) {
+            this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          try {
+            const groups: FleetGroup[] = JSON.parse(stdout);
+            resolve(groups);
+          } catch {
+            resolve([]);
+          }
+        }
+      );
+    });
+  }
+
+  /**
+   * `wendy fleet group show <group> --json`
+   * Lists the devices in a named group.
+   */
+  async showGroup(group: string): Promise<FleetDevice[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+    const args = ["--json", "fleet", "group", "show", group];
+    this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        args,
+        { env: analyticsDisabledEnv() },
+        (error, stdout, stderr) => {
+          if (error) {
+            this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          try {
+            const devices: FleetDevice[] = JSON.parse(stdout);
+            resolve(devices);
+          } catch {
+            resolve([]);
+          }
+        }
+      );
+    });
+  }
+
+  /**
+   * `wendy fleet group add <group> <device>... --json`
+   * Adds one or more devices to a group.
+   */
+  async addDevicesToGroup(
+    group: string,
+    devices: string[]
+  ): Promise<FleetMembershipResult[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+    const args = ["--json", "fleet", "group", "add", group, ...devices];
+    this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+    return new Promise((resolve, reject) => {
+      execFile(cli.path, args, (error, stdout, stderr) => {
+        if (error) {
+          // Partial failures exit non-zero but produce JSON — try to parse first.
+          try {
+            const results: FleetMembershipResult[] = JSON.parse(stdout);
+            resolve(results);
+            return;
+          } catch {
+            // fall through
+          }
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
+          reject(new Error(stderr || error.message));
+          return;
+        }
+        try {
+          const results: FleetMembershipResult[] = JSON.parse(stdout);
+          resolve(results);
+        } catch {
+          resolve([]);
+        }
+      });
+    });
+  }
+
+  /**
+   * `wendy fleet group rm <group> <device>... --json`
+   * Removes one or more devices from a group.
+   */
+  async removeDevicesFromGroup(
+    group: string,
+    devices: string[]
+  ): Promise<FleetMembershipResult[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+    const args = ["--json", "fleet", "group", "rm", group, ...devices];
+    this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+    return new Promise((resolve, reject) => {
+      execFile(cli.path, args, (error, stdout, stderr) => {
+        if (error) {
+          try {
+            const results: FleetMembershipResult[] = JSON.parse(stdout);
+            resolve(results);
+            return;
+          } catch {
+            // fall through
+          }
+          this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
+          reject(new Error(stderr || error.message));
+          return;
+        }
+        try {
+          const results: FleetMembershipResult[] = JSON.parse(stdout);
+          resolve(results);
+        } catch {
+          resolve([]);
+        }
+      });
+    });
+  }
+
+  /**
+   * `wendy fleet apps [--group <group>] --json`
+   * Lists apps running across the group (or all devices if group is omitted).
+   */
+  async listApps(group?: string): Promise<FleetAppRow[]> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+    const args = ["--json", "fleet", "apps"];
+    if (group) {
+      args.push("--group", group);
+    }
+    this.outputChannel.appendLine(`Executing: ${cli.path} ${args.join(" ")}`);
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        cli.path,
+        args,
+        { env: analyticsDisabledEnv() },
+        (error, stdout, stderr) => {
+          if (error) {
+            this.outputChannel.appendLine(`Error: ${stderr || error.message}`);
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          try {
+            const rows: FleetAppRow[] = JSON.parse(stdout);
+            resolve(rows);
+          } catch {
+            resolve([]);
+          }
+        }
+      );
+    });
+  }
+
+  /**
+   * Opens a terminal running `wendy fleet run --group <group>`.
+   *
+   * Like `wendy run`, this streams multi-device build/deploy output and is
+   * always user-initiated, so it runs in a terminal rather than via execFile.
+   */
+  async runFleet(
+    group: string,
+    projectPath: string,
+    options: FleetRunOptions = {}
+  ): Promise<void> {
+    const cli = await WendyCLI.create();
+    if (!cli) {
+      throw new Error("Wendy CLI not found");
+    }
+
+    const args = ["fleet", "run", "--group", group];
+    if (options.keepGoing) {
+      args.push("--keep-going");
+    }
+    if (options.debug) {
+      args.push("--debug");
+    }
+
+    const terminal = vscode.window.createTerminal({
+      name: `Wendy Fleet: ${group}`,
+      cwd: projectPath,
+    });
+    terminal.show();
+    terminal.sendText(`${cli.path} ${args.join(" ")}`);
+  }
+}

--- a/src/sidebar/FleetProvider.ts
+++ b/src/sidebar/FleetProvider.ts
@@ -1,0 +1,111 @@
+import * as vscode from "vscode";
+import { FleetManager, FleetGroup, FleetDevice } from "../models/FleetManager";
+
+type FleetTreeItem = FleetGroupItem | FleetDeviceItem | FleetEmptyItem;
+
+/**
+ * Represents a device group in the Fleet sidebar tree.
+ */
+export class FleetGroupItem extends vscode.TreeItem {
+  readonly kind = "group" as const;
+
+  constructor(public readonly group: FleetGroup) {
+    super(group.group, vscode.TreeItemCollapsibleState.Collapsed);
+    this.description = `${group.devices} device${group.devices === 1 ? "" : "s"}`;
+    this.contextValue = "fleetGroup";
+    this.iconPath = new vscode.ThemeIcon("layers");
+    this.tooltip = `Group: ${group.group} — ${group.devices} device(s)`;
+  }
+}
+
+/**
+ * Represents a device that is a member of a fleet group in the sidebar tree.
+ */
+export class FleetDeviceItem extends vscode.TreeItem {
+  readonly kind = "device" as const;
+
+  constructor(
+    public readonly device: FleetDevice,
+    public readonly groupName: string
+  ) {
+    super(device.name, vscode.TreeItemCollapsibleState.None);
+    this.description = device.address || device.type;
+    this.contextValue = "fleetDevice";
+    this.iconPath = new vscode.ThemeIcon("device-desktop");
+    this.tooltip = `${device.name} (id: ${device.id}${device.address ? ", " + device.address : ""})`;
+  }
+}
+
+/**
+ * Placeholder item shown when there are no groups yet.
+ */
+class FleetEmptyItem extends vscode.TreeItem {
+  readonly kind = "empty" as const;
+
+  constructor() {
+    super("No device groups yet", vscode.TreeItemCollapsibleState.None);
+    this.description = "Use 'wendy fleet group add' to create one";
+    this.contextValue = "fleetEmpty";
+    this.iconPath = new vscode.ThemeIcon("info");
+  }
+}
+
+/**
+ * Tree data provider for the Fleet sidebar view (wendyFleet).
+ *
+ * Shows the output of `wendy fleet group ls` as top-level nodes. Expanding a
+ * group node calls `wendy fleet group show` to list its member devices.
+ *
+ * Registered against the view ID `wendyFleet` declared in package.json.
+ */
+export class FleetProvider
+  implements vscode.TreeDataProvider<FleetTreeItem>
+{
+  private _onDidChangeTreeData = new vscode.EventEmitter<
+    FleetTreeItem | undefined | null | void
+  >();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  constructor(private readonly fleetManager: FleetManager) {}
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: FleetTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(element?: FleetTreeItem): Promise<FleetTreeItem[]> {
+    if (!element) {
+      // Root: list all groups.
+      try {
+        const groups = await this.fleetManager.listGroups();
+        if (groups.length === 0) {
+          return [new FleetEmptyItem()];
+        }
+        return groups.map((g) => new FleetGroupItem(g));
+      } catch {
+        return [new FleetEmptyItem()];
+      }
+    }
+
+    if (element.kind === "group") {
+      // Group node: list member devices.
+      try {
+        const devices = await this.fleetManager.showGroup(element.group.group);
+        if (devices.length === 0) {
+          const empty = new FleetEmptyItem();
+          empty.label = "No devices in this group";
+          empty.description = "";
+          return [empty];
+        }
+        return devices.map((d) => new FleetDeviceItem(d, element.group.group));
+      } catch {
+        return [];
+      }
+    }
+
+    return [];
+  }
+}


### PR DESCRIPTION
The CLI gained a `wendy fleet` namespace with three commands: `wendy fleet group ls|show|add|rm` (device group management), `wendy fleet apps [--group <g>]` (per-group app inventory), and `wendy fleet run --group <g>` (fan-out deploy). The extension should surface these by:

1. Adding a `FleetManager` model that wraps the new CLI commands (`fleet group ls`, `fleet group show`, `fleet group add`, `fleet group rm`, `fleet apps`, `fleet run`).
2. Adding a `FleetProvider` tree-view sidebar provider that lists groups (from `fleet group ls --json`) and their member devices (from `fleet group show --json`), with commands to add/remove devices from groups and run `fleet apps` or `fleet run` against a group.
3. Registering the new `wendyFleet.*` commands in `extension.ts`.
4. Adding the new view, commands, and menus to `package.json`.
