### PR TITLE
feat(vscode): proposal for WendyOS#1398

### DIFF
--- a/schemas/wendy-schema.json
+++ b/schemas/wendy-schema.json
@@ -145,6 +145,11 @@
       "description": "Per-service configuration overrides. A service-level `frameworks.ros2` block takes precedence over the app-level block.",
       "additionalProperties": false,
       "properties": {
+        "context": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Build context path for this service, relative to wendy.json (e.g. \".\" for the project root). Used to locate the Dockerfile when each service has its own build directory."
+        },
         "frameworks": {
           "$ref": "#/$defs/frameworks"
         },


### PR DESCRIPTION
The CLI adds `wendy device foxglove serve`, which generates a `wendy.json` whose `services` entries include a `"context": "."` field (visible in both the generated template in `foxglove.go` and the reference `Examples/FoxgloveBridge/wendy.json`). The extension's JSON Schema for `wendy.json` (`schemas/wendy-schema.json`) defines `serviceConfig` with `"additionalProperties": false` and no `context` property, so any `wendy.json` produced by or modelled on this command will show a schema validation error in VS Code ("Additional property context is not allowed"). The fix is to add `context` as an optional string property to the `serviceConfig` definition in the schema.
