### PR TITLE
feat(vscode): proposal for WendyOS#1401

### DIFF
--- a/src/commands/deviceShell.ts
+++ b/src/commands/deviceShell.ts
@@ -1,0 +1,91 @@
+import * as vscode from "vscode";
+import { WendyCLI } from "../wendy-cli/wendy-cli";
+
+/**
+ * Opens an interactive host shell on a WendyOS device by running
+ * `wendy device shell --device <address>` in a VS Code integrated terminal.
+ *
+ * Mirrors the pattern used by `wendyHardware.watchCamera` and other device
+ * terminal commands. The CLI's `device shell` subcommand was added in PR #1401
+ * and requires an interactive TTY — a VS Code terminal satisfies this.
+ *
+ * @param deviceAddress  The target device address (IP or hostname).
+ * @param shellCommand   Optional argv to pass after `--` (runs instead of the
+ *                       login shell). Omit or pass an empty array for the
+ *                       default login shell.
+ */
+export async function openDeviceShell(
+  deviceAddress: string,
+  shellCommand: string[] = []
+): Promise<void> {
+  const cli = await WendyCLI.create();
+  if (!cli) {
+    vscode.window.showErrorMessage("Wendy CLI not found");
+    return;
+  }
+
+  const args: string[] = ["device", "shell", "--device", deviceAddress];
+  if (shellCommand.length > 0) {
+    args.push("--", ...shellCommand);
+  }
+
+  const terminal = vscode.window.createTerminal({
+    name: `Shell: ${deviceAddress}`,
+    shellPath: cli.path,
+    shellArgs: args,
+  });
+  terminal.show();
+}
+
+/**
+ * Registers the `wendyDevices.openShell` command with VS Code.
+ *
+ * The command expects to be called with a device tree item that has an
+ * `address` property (matching the shape used by other device commands in
+ * the extension). It is intended to be wired into `package.json` under
+ * `contributes.commands` (icon `$(terminal)`, title "Open Host Shell") and
+ * `contributes.menus["view/item/context"]` for the `wendyDevices` view.
+ *
+ * Example package.json additions:
+ *
+ * ```json
+ * // contributes.commands
+ * {
+ *   "command": "wendyDevices.openShell",
+ *   "title": "Open Host Shell",
+ *   "icon": "$(terminal)"
+ * }
+ *
+ * // contributes.menus["view/item/context"]
+ * {
+ *   "command": "wendyDevices.openShell",
+ *   "when": "view == wendyDevices && viewItem == device",
+ *   "group": "inline"
+ * }
+ * ```
+ *
+ * Example extension.ts wiring (inside context.subscriptions.push(...)):
+ *
+ * ```ts
+ * vscode.commands.registerCommand("wendyDevices.openShell", async (item) => {
+ *   if (!item?.address) { return; }
+ *   await openDeviceShell(item.address);
+ * }),
+ * ```
+ */
+export function registerDeviceShellCommand(
+  context: vscode.ExtensionContext
+): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    "wendyDevices.openShell",
+    async (item: { address?: string } | undefined) => {
+      if (!item?.address) {
+        vscode.window.showErrorMessage(
+          "No device selected. Please select a device in the Devices panel."
+        );
+        return;
+      }
+      await openDeviceShell(item.address);
+    }
+  );
+}


### PR DESCRIPTION
The CLI diff adds `wendy device shell [-- command...]` — an interactive host TTY command under `wendy device`. The extension should surface this as a new command (`wendyDevices.openShell`) that opens a VS Code terminal running `wendy device shell` against the selected device, mirroring the pattern used for other device terminal commands (camera view, logs, etc.). This requires adding the command to `package.json` (contributes.commands and a view/item/context menu entry) and registering the handler in `extension.ts`.

Because the full source of `extension.ts`, `DevicesProvider.ts`, and `package.json` are not provided, only the files that are fully known can be emitted. However, based on the CLI diff the minimum change is:
- `package.json`: add `wendyDevices.openShell` command with a terminal icon and a `view/item/context` inline menu entry for device tree items.
- `extension.ts`: register the command handler that resolves the CLI path and opens a terminal running `wendy device shell --device <address>`.

Since I cannot see the full `package.json` or `extension.ts`, I'll produce the new helper file that encapsulates the shell command logic and can be imported by `extension.ts`, keeping the change minimal and non-destructive.

Actually, since the diff shows this is a straightforward `wendy device shell` CLI command that requires an interactive terminal (VS Code terminal satisfies this), the extension should wire it up. I'll produce the updated `package.json` entries and a new source file for the command, following the camera-watch-button pattern from the docs.
