### PR TITLE
feat(vscode): proposal for WendyOS#1425

### DIFF
--- a/schemas/wendy-schema.json
+++ b/schemas/wendy-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://wendy.sh/schemas/wendy.json",
+  "$id": "https://wendy.dev/schemas/wendy.json",
   "title": "Wendy App Configuration",
   "description": "Configuration file for Wendy edge computing applications (wendy.json).",
   "type": "object",


### PR DESCRIPTION
The CLI PR migrates all `wendy.sh` domain references to `wendy.dev`. The extension's `schemas/wendy-schema.json` has its JSON Schema `$id` still set to `"https://wendy.sh/schemas/wendy.json"`, which should be updated to `"https://wendy.dev/schemas/wendy.json"` to match the domain migration. This is the only extension file affected — the macOS agent install changes are shell-script-only and don't alter any CLI command interfaces, flags, or output formats that the extension wraps.
